### PR TITLE
Issue 5: Generate predictable and automatic ids

### DIFF
--- a/src/helpers/isBrowser.ts
+++ b/src/helpers/isBrowser.ts
@@ -6,7 +6,7 @@
  */
 
 /**
- * isBrowser.ts
+ * Checkes wether the user is running the app on a browser or under another type of environment.
  *
  * @author João Dias <joao.dias@feedzai.com>
  * @since 1.0.0

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -13,3 +13,4 @@
  */
 export * from "./usePrevious";
 export * from "./useSafeLayoutEffect";
+export * from "./useAutoId";

--- a/src/hooks/useAutoId.ts
+++ b/src/hooks/useAutoId.ts
@@ -1,0 +1,64 @@
+/*
+ * Please refer to the terms of the license
+ * agreement.
+ *
+ * (c) 2021 Feedzai, Rights Reserved.
+ */
+
+/**
+ * useAutoId.ts
+ *
+ * @author João Dias <joao.dias@feedzai.com>
+ * @since 1.1.0
+ */
+import { useLayoutEffect, useEffect, useState } from "react";
+
+let hasHydrated = false;
+let id = 0;
+
+/**
+ * Returns an incremented id number
+ *
+ * @returns {number}
+ */
+const generateIncrementalId = () => ++id;
+
+/**
+ * Generate automatic IDs to facilitate WAI-ARIA
+ *
+ * The returned ID will initially be `null` and will update after a
+ * component mounts. Users may need to supply their own ID if they need
+ * consistent values for SSR.
+ */
+function useAutoId(customId: string): string;
+function useAutoId(customId: string | undefined): string | undefined;
+function useAutoId(customId?: null): string | undefined;
+function useAutoId(customId?: string | null) {
+	const initialId = customId || (hasHydrated ? generateIncrementalId() : null);
+	const [id, setId] = useState(initialId);
+
+	/*
+	* Patch the ID after render to avoid any rendering flicker.
+	*/
+	useLayoutEffect(() => {
+		if (id === null) {
+			setId(generateIncrementalId());
+		}
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
+	/*
+	* Flag all future uses of `useAutoId` to skip the updating cycle.
+	* We use `useEffect` because it happens after `useLayoutEffect`.
+	* This way we make sure that we complete the patch process until the end.
+	*/
+	useEffect(() => {
+		if (hasHydrated === false) {
+			hasHydrated = true;
+		}
+	}, []);
+
+	return id != null ? String(id) : undefined;
+}
+
+export { useAutoId };

--- a/src/hooks/useSafeLayoutEffect.ts
+++ b/src/hooks/useSafeLayoutEffect.ts
@@ -12,7 +12,7 @@
  * @author João Dias <joao.dias@feedzai.com>
  * @since 1.0.0
  */
-import { useLayoutEffect } from "react";
+import { useLayoutEffect, useEffect } from "react";
 import { isBrowser } from "../helpers/isBrowser";
 
 /**
@@ -22,4 +22,4 @@ import { isBrowser } from "../helpers/isBrowser";
  */
 export const useSafeLayoutEffect = isBrowser
 	? useLayoutEffect
-	: /* istanbul ignore next */ () => { };
+	: useEffect;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,8 +13,14 @@
  * @since 1.0.0
  */
 export { MessagesAnnouncer, useMessagesAnnouncer } from "./components/announcer/messages/index";
-export { RouteAnnouncer } from "./components/announcer/route-announcer";
+export {
+	RouteAnnouncer,
+	getHeadingText,
+	hasDocumentTitle,
+} from "./components/announcer/route-announcer";
 export { KeyboardOnly } from "./components/keyboard-only";
 export { FocusManager, useFocusManager } from "./components/focus-manager/index";
 export { SkipLinks } from "./components/skip-links";
 export { RoverProvider, useRover, useFocus } from "./components/roving-tabindex/index";
+export { focusWithoutScrolling, isBrowser, runAfterTransition } from "./helpers/index";
+export { useAutoId, useSafeLayoutEffect } from "./hooks";

--- a/test/hooks/useAutoId.test.tsx
+++ b/test/hooks/useAutoId.test.tsx
@@ -1,0 +1,48 @@
+/*
+ * Please refer to the terms of the license
+ * agreement.
+ *
+ * (c) 2021 Feedzai, Rights Reserved.
+ */
+
+/**
+ * useAutoId.test.tsx
+ *
+ * @author João Dias <joao.dias@feedzai.com>
+ * @since 1.1.0
+ */
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { useAutoId } from "../../src/hooks/useAutoId";
+
+function DemoComponent() {
+	const value = null;
+	const firstId = useAutoId(value);
+	const secondId = useAutoId();
+	return (
+		<div>
+			<p id={firstId}>A paragraph</p>
+			<span id={secondId}>An inline span element</span>
+		</div>
+	);
+}
+
+function FallbackDemo() {
+	const id = useAutoId("fdz-fallback-id");
+	return <h1 id={id}>Feedzai</h1>;
+}
+
+describe("useAutoId", () => {
+	it("should generate a unique ID value", () => {
+		render(<DemoComponent />);
+		const idOne = Number(screen.getByText("A paragraph").id);
+		const idTwo = Number(screen.getByText("An inline span element").id);
+
+		expect(idTwo).not.toEqual(idOne);
+	});
+
+	it("uses a fallback ID", () => {
+		render(<FallbackDemo />);
+		expect(screen.getByText("Feedzai").id).toEqual("fdz-fallback-id");
+	});
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,5 +27,5 @@
 		"types": ["node", "jest"]
 	},
 	"exclude": ["node_modules", "dist", "coverage", "**/stories/*", "**/*.spec.tsx", "**/*.spec.js"],
-	"include": ["src", "test"]
+	"include": ["src"]
 }


### PR DESCRIPTION
#### Because:
* Accessibility APIs rely heavily on element IDs and requiring developers to put IDs on every element on a component library is both cumbersome and error-prone, there should be a way to generate IDs for them.

#### This commit: 
* Adds a new hook called `useAutoId`
* Exports other hooks to be used (`usePrevious` and `useSafeLayoutEffect`)
* Removes the `tests` folder from the tsc type generation step.