### PR TITLE
Add Visually Hidden Component

### DIFF
--- a/cypress/test/components/visually-hidden/index.spec.tsx
+++ b/cypress/test/components/visually-hidden/index.spec.tsx
@@ -1,0 +1,86 @@
+/*
+ * Please refer to the terms of the license
+ * agreement.
+ *
+ * (c) 2021 Feedzai, Rights Reserved.
+ */
+/// <reference types="@testing-library/cypress" />
+/**
+ * index.spec.tsx
+ *
+ * @author João Dias <joao.dias@feedzai.com>
+ * @since 1.0.0
+ */
+import React from "react";
+import { mount as render } from "@cypress/react";
+import {
+	VisuallyHidden,
+	VisuallyHiddenProps,
+	DEFAULT_PROPS,
+} from "../../../../src/components/visually-hidden";
+
+const DemoContent = <GenericElement extends React.ElementType>(
+	props: VisuallyHiddenProps<GenericElement>,
+) => {
+	return (
+		<div
+			style={{
+				display: "grid",
+				placeItems: "center",
+				height: "200px",
+				width: "100%",
+			}}
+		>
+			<button id="064a70e8-5c1e-43e6-8eee-9ab069b094fc" type="button">
+				<VisuallyHidden {...props}>Press Enter to </VisuallyHidden>Return to Navigation
+			</button>
+		</div>
+	);
+};
+
+describe("<VisuallyHidden>", () => {
+	let props = DEFAULT_PROPS;
+
+	it("should render the text visually hidden", () => {
+		render(<DemoContent {...props} />);
+
+		cy.findByRole("button").should("have.text", "Press Enter to Return to Navigation");
+		cy.findByTestId("fdz-js-visually-hidden")
+			.should("exist")
+			.and("have.css", "position", "absolute")
+			.and("have.css", "clip", "rect(0px, 0px, 0px, 0px)")
+			.and("have.css", "overflow", "hidden");
+	});
+
+	it("should render the component with a different tagname", () => {
+		props = {
+			...props,
+			as: "div",
+		};
+
+		render(<DemoContent {...props} />);
+
+		cy.findByTestId("fdz-js-visually-hidden").should("have.prop", "tagName").should("eq", "DIV");
+	});
+
+	it("should render a set of html attributes", () => {
+		props = {
+			...props,
+			id: "60007f76-6d72-4a94-8161-16a7ea22e62b",
+			className: "a-custom-classname",
+			"data-custom-attribute": "custom-value",
+			style: {
+				accentColor: "hotpink",
+				cursor: "pointer",
+			},
+		};
+
+		render(<DemoContent {...props} />);
+
+		cy.findByTestId("fdz-js-visually-hidden")
+			.and("have.class", "a-custom-classname")
+			.and("have.css", "cursor", "pointer")
+			.and("have.css", "accent-color", "rgb(255, 105, 180)")
+			.and("have.attr", "data-custom-attribute", "custom-value");
+	});
+});

--- a/documentation/docs/content-and-navigation/demos/index.tsx
+++ b/documentation/docs/content-and-navigation/demos/index.tsx
@@ -1,2 +1,3 @@
 export * from "./skip-links";
 export * from "./semantic-headings";
+export * from "./visually-hidden";

--- a/documentation/docs/content-and-navigation/demos/visually-hidden.tsx
+++ b/documentation/docs/content-and-navigation/demos/visually-hidden.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useRef, useState } from "react";
+import { VisuallyHidden } from "../../../../src";
+import styles from "./styles.module.scss";
+
+const ELEMENT_ID = "064a70e8-5c1e-43e6-8eee-9ab069b094fc";
+
+export const DemoVisuallyHidden = () => {
+	const [buttonText, setButtonText] = useState("");
+	const ref = useRef<HTMLButtonElement>(null);
+
+	useEffect(() => {
+		if (ref.current && ref.current.textContent) {
+			setButtonText(ref.current.textContent);
+		}
+	}, [setButtonText]);
+	return (
+		<>
+			<button
+				ref={ref}
+				id={ELEMENT_ID}
+				className={styles.skipLinks__button}
+				data-testid="fdz-js-skip-links-target-button"
+			>
+				<VisuallyHidden>Press Enter to </VisuallyHidden>
+				<span>Return to Navigation</span>
+			</button>
+			<br />
+			<br />
+			<div>
+				<h4>Button content:</h4>
+				<p>"{buttonText}"</p>
+			</div>
+		</>
+	);
+};

--- a/documentation/docs/content-and-navigation/visually-hidden.mdx
+++ b/documentation/docs/content-and-navigation/visually-hidden.mdx
@@ -1,0 +1,19 @@
+---
+sidebar_position: 3
+title: Visually Hidden
+---
+
+import { DemoVisuallyHidden } from "./demos";
+import { Subtitle, BrowserWindow, PropsTable } from "../../src/components/index";
+
+<Subtitle>Hides its children visually, while keeping content visible to screen readers.</Subtitle>
+
+<BrowserWindow>
+	<DemoVisuallyHidden />
+</BrowserWindow>
+<br />
+
+Visually hidden is a common technique used in web accessibility to hide content from the visual client, but keep it readable for screen readers.
+This component renders html `<span>` as a proxy.
+
+<PropsTable name="VisuallyHidden" />

--- a/src/components/visually-hidden/index.tsx
+++ b/src/components/visually-hidden/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * Please refer to the terms of the license agreement.
+ *
+ * (c) 2021 Feedzai, Rights Reserved.
+ */
+
+/**
+ * index.tsx
+ *
+ * @author João Dias <joao.dias@feedzai.com>
+ * @since 1.0.0
+ */
+import React, { useRef } from "react";
+import { makeId } from "../../helpers";
+import { useAutoId } from "../../hooks";
+import { CommonElement } from "../../typings/common";
+import { PolymorphicComponentProps } from "../../typings/polymorphic";
+
+/**
+ * Styles to visually hide an element
+ * but make it accessible to screen-readers
+ */
+export const visuallyHiddenStyle: React.CSSProperties = {
+	border: "0px",
+	clip: "rect(0px, 0px, 0px, 0px)",
+	margin: "-1px",
+	overflow: "hidden",
+	height: "1px",
+	width: "1px",
+	padding: "0",
+	position: "absolute",
+	whiteSpace: "nowrap",
+};
+
+export type VisuallyHiddenProps<C extends React.ElementType> = PolymorphicComponentProps<
+	C,
+	CommonElement<C>
+>;
+
+const DEFAULT_ELEMENT_TAG = "span";
+
+export const DEFAULT_PROPS: Partial<VisuallyHiddenProps<"span">> = {
+	"data-testid": "fdz-js-visually-hidden",
+};
+
+/**
+ * A utility component that can be used to hide its children visually,
+ * while keeping them visible to screen readers and other assistive technology.
+ *
+ * @example
+ *
+ * // Rendering visually hidden text
+ * <button type="button"><VisuallyHidden as="div">Press Enter to</VisuallyHidden>Return to Navigation</button>
+ *
+ * // Visually, it will be rendered a button with the text:
+ * "Return to Navigation"
+ *
+ * // But a screen-reader will read as:
+ * "Press Enter to Return to Navigation.button"
+ *
+ * @param {React.FC<CommonElement<HTMLSpanElement>>} props
+ * @returns {JSX.Element}
+ */
+export const VisuallyHidden = <GenericElement extends React.ElementType = "span">({
+	as,
+	id,
+	"data-testid": dataTestId = DEFAULT_PROPS["data-testid"],
+	style,
+	children,
+	...props
+}: VisuallyHiddenProps<GenericElement>) => {
+	const autoId = useAutoId(id);
+	const { current: generatedId } = useRef(makeId(dataTestId, autoId));
+	const componentStyles = {
+		...visuallyHiddenStyle,
+		...style,
+	};
+	const Component = as || DEFAULT_ELEMENT_TAG;
+
+	return (
+		<Component id={generatedId} data-testid={dataTestId} {...props} style={componentStyles}>
+			{children}
+		</Component>
+	);
+};

--- a/src/helpers/callIfExists.ts
+++ b/src/helpers/callIfExists.ts
@@ -3,6 +3,14 @@ import { isFunction } from "../helpers";
 /**
  * Executes the given callback function, if present.
  *
+ * @example
+ *
+ * // Calling a function with several arguments
+ * callIfExists(functionName, arg1, arg2);
+ *
+ * // Calling a function without any argument
+ * callIfExists(functionName);
+ *
  * @param {Function|undefined} callback Holds the callback to be executed.
  * @param {any[]} args Holds a list of arguments to be passed to the callback.
  * @private

--- a/src/helpers/focus-without-scrolling.ts
+++ b/src/helpers/focus-without-scrolling.ts
@@ -60,6 +60,16 @@ function restoreScrollPosition(IScrollableElements: IScrollableElement[]) {
 }
 
 /**
+ * Places focus on an `HTMLElement` without causing a page scroll.
+ *
+ * @example
+ *
+ * // Placing focus on a button
+ * const element = document.querySelector("button.some-css-class");
+ *
+ * if (element) {
+ *    focusWithoutScrolling(element);
+ * }
  * @export
  * @param {HTMLElement} element
  */

--- a/src/helpers/make-id.ts
+++ b/src/helpers/make-id.ts
@@ -15,8 +15,16 @@
 /**
  * Joins strings to format IDs for compound components.
  *
+ * @example
+ *
+ * // Custom generated id by using the `useAutoId` hook and the `makeId` function
+ * // to join the auto-generated id with a custom string
+ * const autoId = useAutoId(id);
+ * const { current: generatedId } = useRef(makeId("fdz-js-tabbable-button-", autoId));
+ *
  * @param args
+ * @returns {string}
  */
 export function makeId(...args: (string | number | null | undefined)[]) {
-	return args.filter((val) => val != null).join("--");
+	return args.filter((val) => val !== null).join("--");
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,4 +33,6 @@ export {
 	useFocus,
 	useRover,
 } from "./components/roving-tabindex/index";
+export { VisuallyHidden, visuallyHiddenStyle } from "./components/visually-hidden";
+export { callIfExists, focusWithoutScrolling, makeId } from "./helpers";
 export { useAutoId, useDisableEvent, useSafeLayoutEffect, useTabbable } from "./hooks";

--- a/src/typings/common.ts
+++ b/src/typings/common.ts
@@ -13,7 +13,20 @@
  * @since 1.1.0
  */
 
-export interface CommonElement {
+type AsProp<GenericComponent extends React.ElementType> = {
+	/**
+	 * An override of the default HTML tag.
+	 * Can also be another React component.
+	 */
+	as?: GenericComponent
+}
+
+/**
+ * Common HTML Element types.
+ *
+ * Accepts a type of element tag, like `"div"`, `"span"`, `"p"`
+ */
+export type CommonElement<GenericElement extends React.ElementType = "div"> = React.HTMLAttributes<HTMLElement> & {
 	/**
 	 * A `data-attribute` identifier for testing purposes
 	 *
@@ -21,12 +34,4 @@ export interface CommonElement {
 	 * @memberof CommonElement
 	 */
 	"data-testid"?: string;
-
-	/**
-	 * Custom CSS Styles
-	 *
-	 * @type {React.CSSProperties}
-	 * @memberof CommonElement
-	 */
-	styles?: React.CSSProperties;
-}
+} & AsProp<GenericElement>

--- a/src/typings/polymorphic.ts
+++ b/src/typings/polymorphic.ts
@@ -1,79 +1,45 @@
 /* eslint-disable @typescript-eslint/ban-types */
-/*
- * Please refer to the terms of the license agreement.
- *
- * (c) 2021 Feedzai, Rights Reserved.
- */
+import React from 'react'
 
-/**
- * polymorphic.ts
- *
- * description
- *
- * @author João Dias <joao.dias@feedzai.com>
- * @since 1.1.0
- */
-import type * as React from "react";
+// Source: https://github.com/emotion-js/emotion/blob/master/packages/styled-base/types/helper.d.ts
+// A more precise version of just React.ComponentPropsWithoutRef on its own
+export type PropsOf<
+	C extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+	> = JSX.LibraryManagedAttributes<C, React.ComponentPropsWithoutRef<C>>
 
-export type Merge<P1 = {}, P2 = {}> = Omit<P1, keyof P2> & P2;
-
-/**
- * Infers the OwnProps if E is a ForwardRefExoticComponentWithAs
- */
-export type OwnProps<E> = E extends ForwardRefComponent<any, infer P> ? P : {};
-
-/**
- * Infers the JSX.IntrinsicElement if E is a ForwardRefExoticComponentWithAs
- */
-export type IntrinsicElement<E> = E extends ForwardRefComponent<infer I, any>
-	? I
-	: never;
-
-export type ForwardRefExoticComponent<E, OwnProps> = React.ForwardRefExoticComponent<
-	Merge<
-		E extends React.ElementType ? React.ComponentPropsWithRef<E> : never,
-		OwnProps & { as?: E }
-	>
->;
-
-export interface ForwardRefComponent<
-	IntrinsicElementString,
-	OwnProps = {}
-	/*
-	 * Extends original type to ensure built in React types play nice with
-	 * polymorphic components still e.g. `React.ElementRef` etc.
+type AsProp<C extends React.ElementType> = {
+	/**
+	 * An override of the default HTML tag.
+	 * Can also be another React component.
 	 */
-	> extends ForwardRefExoticComponent<IntrinsicElementString, OwnProps> {
-	/*
-	 * When `as` prop is passed, use this overload. Merges original own props
-	 * (without DOM props) and the inferred props from `as` element with the own
-	 * props taking precendence.
-	 *
-	 * We explicitly avoid `React.ElementType` and manually narrow the prop types
-	 * so that events are typed when using JSX.IntrinsicElements.
-	 */
-	<As = IntrinsicElementString>(
-		props: As extends ""
-			? { as: keyof JSX.IntrinsicElements }
-			: As extends React.ComponentType<infer P>
-			? Merge<P, OwnProps & { as: As }>
-			: As extends keyof JSX.IntrinsicElements
-			? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
-			: never
-	): React.ReactElement | null;
+	as?: C
 }
 
-export interface MemoComponent<IntrinsicElementString, OwnProps = {}>
-	extends React.MemoExoticComponent<
-	ForwardRefComponent<IntrinsicElementString, OwnProps>
-	> {
-	<As = IntrinsicElementString>(
-		props: As extends ""
-			? { as: keyof JSX.IntrinsicElements }
-			: As extends React.ComponentType<infer P>
-			? Merge<P, OwnProps & { as: As }>
-			: As extends keyof JSX.IntrinsicElements
-			? Merge<JSX.IntrinsicElements[As], OwnProps & { as: As }>
-			: never
-	): React.ReactElement | null;
-}
+/**
+ * Allows for extending a set of props (`ExtendedProps`) by an overriding set of props
+ * (`OverrideProps`), ensuring that any duplicates are overridden by the overriding
+ * set of props.
+ */
+export type ExtendableProps<
+	ExtendedProps = {},
+	OverrideProps = {}
+	> = OverrideProps & Omit<ExtendedProps, keyof OverrideProps>
+
+/**
+ * Allows for inheriting the props from the specified element type so that
+ * props like children, className & style work, as well as element-specific
+ * attributes like aria roles. The component (`C`) must be passed in.
+ */
+export type InheritableElementProps<
+	C extends React.ElementType,
+	Props = {}
+	> = ExtendableProps<PropsOf<C>, Props>
+
+/**
+ * A more sophisticated version of `InheritableElementProps` where
+ * the passed in `as` prop will determine which props can be included
+ */
+export type PolymorphicComponentProps<
+	C extends React.ElementType,
+	Props = {}
+	> = InheritableElementProps<C, Props & AsProp<C>>


### PR DESCRIPTION
### **Because**:
* There is the need to create a new component that visually hides any content from the user - but still makes it available for screen-readers
* There were a couple of helper functions that weren't being exported in the final bundle.

### **This Commit**:
* Create a new polymorphic component that accepts any type of JSX children and render itself as any type of component (albeit its default tagname being a `span`).
* It hides visually, but still remains visible for the accessible tree and thus, visible for any screen reader.
* Adds component tests for the new component
* Adds documentation as well
* Exports a couple of helper functions for the final bundle and improves their jsdoc

