### PR TITLE
feat: Add support for prefix on the useAutoId

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-	"presets": ["@babel/preset-typescript"],
+	"presets": [["@babel/preset-env"], "@babel/preset-react", "@babel/preset-typescript"],
 	"plugins": ["istanbul", "@babel/plugin-proposal-optional-chaining"]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,12 @@ pids
 lib-cov
 
 # Coverage directory used by tools like istanbul
-coverage
-cypress-coverage
-jest-coverage
-cypress/results/
+coverage/
+.sonar/
+coverage-reports
+.nyc_output
+cypress/results
+cypress/screenshots
 
 # Grunt intermediate storage (http://gruntjs.com/creating-plugins#storing-task-files)
 .grunt
@@ -138,10 +140,11 @@ bundlestats.json
 
 node_modules/
 jest-coverage
+coverage/
+.sonar/
+coverage-reports
 .nyc_output
-coverage
-cypress-coverage/
-cypress/videos
+cypress/results
 cypress/screenshots
 reports
 results

--- a/cypress.json
+++ b/cypress.json
@@ -1,12 +1,5 @@
 {
-	"reporter": "mochawesome",
-	"reporterOptions": {
-		"reportDir": "cypress/results",
-		"overwrite": false,
-		"html": false,
-		"json": true
-	},
-	"baseUrl": "http://localhost:3000",
+	"baseUrl": "http://localhost:3000/react-a11y-tools",
 	"viewportWidth": 1280,
 	"viewportHeight": 800,
 	"component": {

--- a/cypress/integration/skip-links.spec.js
+++ b/cypress/integration/skip-links.spec.js
@@ -13,7 +13,7 @@
  * @author João Dias <joao.dias@feedzai.com>
  * @since 1.0.0
  */
-const ROVER_STORY_URL = "/docs/navigation/skip-links";
+const ROVER_STORY_URL = "/docs/content-and-navigation/skip-links";
 
 describe("Skip Links", () => {
 	beforeEach(() => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -11,7 +11,8 @@
  * @author João Dias <joao.dias@feedzai.com>
  * @since 1.0.0
  */
-require("@cypress/snapshot").register();
-
 import "@cypress/code-coverage/support";
 import "./commands";
+import { register } from "@cypress/snapshot";
+
+register();

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,8 +5,8 @@ module.exports = {
 	},
 	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
 	collectCoverage: true,
-	coverageDirectory: "<rootDir>/jest-coverage",
-	coverageReporters: ["json"],
+	coverageDirectory: "<rootDir>/coverage-reports/jest",
+	coverageReporters: ["lcov", "json"],
 	testURL: "http://localhost/",
 	setupFiles: ["raf/polyfill"],
 	moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
 		"documentation:start": "cd ./documentation && npm run start",
 		"documentation:build": "cd ./documentation && npm run build",
 		"documentation:deploy": "cd ./documentation && GIT_USER=feedzai && npm run deploy",
-		"reinstall": "shx rm -rf node_modules && npm install",
-		"pretest": "shx rm -rf .nyc_output jest-coverage cypress-coverage reports coverage || true",
-		"report:combined": "node ./scripts/merge-coverage.js",
+		"reinstall": "rm -rf node_modules && npm install",
+		"coverage:clean": "rm -rf .nyc_output coverage-reports coverage || true",
+		"coverage:merge": "node ./scripts/merge-coverage.js",
+		"pretest": "npm run coverage:clean",
 		"test:jest": "jest --env=jsdom --coverage --passWithNoTests",
 		"test:jest-ci": "jest --env=jsdom --ci --coverage --maxWorkers=2",
 		"test:ct-open": "cypress open-ct",
@@ -34,7 +35,7 @@
 		"test:components": "npm run test:jest && npm run test:ct",
 		"test:cypress": "cypress open",
 		"test:e2e": "start-server-and-test documentation:start 3000 'cypress run'",
-		"test": "npm run test:components && npm run test:e2e && npm run report:combined"
+		"test": "npm run test:components && npm run test:e2e && npm run coverage:merge"
 	},
 	"peerDependencies": {
 		"react": ">=16.14.0",
@@ -46,6 +47,7 @@
 	},
 	"devDependencies": {
 		"@babel/core": "7.15.8",
+		"@babel/helper-environment-visitor": "^7.16.7",
 		"@babel/plugin-proposal-optional-chaining": "7.14.5",
 		"@babel/preset-env": "7.15.8",
 		"@babel/preset-react": "7.14.5",
@@ -63,7 +65,7 @@
 		"@testing-library/react-hooks": "7.0.2",
 		"@testing-library/user-event": "13.5.0",
 		"@types/classnames": "2.3.0",
-		"@types/jest": "27.0.2",
+		"@types/jest": "^27.4.0",
 		"@types/jsdom": "16.2.13",
 		"@types/node": "16.11.3",
 		"@types/react": "17.0.31",
@@ -105,9 +107,6 @@
 		"jest": "27.3.1",
 		"jsdom": "16.6.0",
 		"lint-staged": "11.2.3",
-		"mochawesome": "6.3.1",
-		"mochawesome-merge": "4.2.0",
-		"mochawesome-report-generator": "5.2.0",
 		"nyc": "15.1.0",
 		"path-browserify": "^1.0.1",
 		"postcss": "8.3.11",
@@ -125,7 +124,6 @@
 		"rollup-plugin-postcss": "4.0.1",
 		"sass": "1.43.3",
 		"sass-loader": "12.2.0",
-		"shx": "0.3.3",
 		"size-limit": "6.0.3",
 		"start-server-and-test": "1.14.0",
 		"style-loader": "^3.3.1",
@@ -167,19 +165,22 @@
 		}
 	],
 	"nyc": {
-		"report-dir": "cypress-coverage",
+		"all": true,
+		"report-dir": "coverage-reports/cypress",
 		"reporter": [
+			"lcov",
 			"json"
 		],
+		"check-coverage": true,
+		"watermarks": {
+			"statements": 95,
+			"branches": 95,
+			"functions": 95,
+			"lines": 95
+		},
 		"include": [
 			"src/**/*"
-		],
-		"exclude": [
-			"test/**"
 		]
 	},
-	"np": {
-		"testScript": "test:jest",
-		"contents": "dist"
-	}
+	"dependencies": {}
 }

--- a/src/components/roving-tabindex/use-focus-effect.ts
+++ b/src/components/roving-tabindex/use-focus-effect.ts
@@ -12,18 +12,41 @@
  * @since 1.0.0
  */
 import { useEffect, RefObject } from "react";
+import { focusWithoutScrolling } from "../../helpers";
 
 /**
- * Invokes focus() on ref as a layout effect whenever focus changes from false to true.
+ * Invokes `focus()` on a DOM element.
+ * Supports for a `ref` as well as an `HTMLElement` or `SVGElement`
  *
- * @param {boolean | null} [focused]
- * @param {RefObject<SVGElement | HTMLElement>} ref
+ * @example
+ *
+ * // Place the focus on an element with a ref
+ * useFocus(buttonRef, true);
+ *
+ * // or
+ * useFocus(buttonRef);
+ *
+ * // Place the focus on an element queried from the DOM
+ * useFocus(document.querySelector("button"), true);
+ *
+ * // Place the focus on an element with a ref, but prevent scrolling when calling the `focus()` method
+ * useFocus(buttonRef, true, false);
+ *
+ * @export
+ * @template GenericElement
+ * @param {RefObject<GenericElement>} element
+ * @param {(boolean)} [willFocus=true]
+ * @param {(boolean)} [scrollWhenFocus=true]
  * @returns {void}
  */
-export function useFocus(ref: RefObject<SVGElement | HTMLElement>, focused?: boolean | null): void {
+export function useFocus<GenericElement extends HTMLElement | SVGElement>(element: RefObject<GenericElement> | GenericElement, willFocus: boolean | undefined = true, scrollWhenFocus: boolean | undefined = true): void {
 	useEffect(() => {
-		if (focused && ref.current) {
-			ref.current.focus();
+		if (willFocus) {
+			const DOMElement = "current" in element ? element.current : element
+
+			if (DOMElement) {
+				scrollWhenFocus ? DOMElement.focus() : focusWithoutScrolling(DOMElement);
+			}
 		}
-	}, [ref, focused]);
+	}, [element, willFocus]);
 }

--- a/src/helpers/focus-without-scrolling.ts
+++ b/src/helpers/focus-without-scrolling.ts
@@ -22,7 +22,7 @@ interface IScrollableElement {
  * @param {HTMLElement} element
  * @returns {IScrollableElement[]}
  */
-function getAllScrollableElements(element: HTMLElement): IScrollableElement[] {
+function getAllScrollableElements<GenericElement extends HTMLElement | SVGElement>(element: GenericElement): IScrollableElement[] {
 	let parent = element.parentNode;
 	const IScrollableElements: IScrollableElement[] = [];
 	const rootScrollingElement = document.scrollingElement || document.documentElement;
@@ -60,7 +60,7 @@ function restoreScrollPosition(IScrollableElements: IScrollableElement[]) {
 }
 
 /**
- * Places focus on an `HTMLElement` without causing a page scroll.
+ * Places focus on an `HTMLElement` or `SVGElement` without causing a page scroll.
  *
  * @example
  *
@@ -73,7 +73,7 @@ function restoreScrollPosition(IScrollableElements: IScrollableElement[]) {
  * @export
  * @param {HTMLElement} element
  */
-export function focusWithoutScrolling(element: HTMLElement): void {
+export function focusWithoutScrolling<GenericElement extends HTMLElement | SVGElement>(element: GenericElement): void {
 	if (supportsPreventScroll()) {
 		element.focus({ preventScroll: true });
 	} else {

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -20,6 +20,7 @@ export * from "./isFunction";
 export * from "./isNumber";
 export * from "./isString";
 export * from "./inRange";
+export * from "./isNil";
 export * from "./run-after-transition";
 export * from "./keyCodes";
 export * from "./merge-event-handlers";

--- a/src/helpers/isNil.ts
+++ b/src/helpers/isNil.ts
@@ -1,0 +1,36 @@
+/*
+ * The copyright of this file belongs to Feedzai. The file cannot be
+ * reproduced in whole or in part, stored in a retrieval system, transmitted
+ * in any form, or by any means electronic, mechanical, or otherwise, without
+ * the prior permission of the owner. Please refer to the terms of the license
+ * agreement.
+ *
+ * (c) 2022 Feedzai, Rights Reserved.
+ */
+
+/**
+ * isNil.ts
+ *
+ * @author João Dias <joao.dias@feedzai.com>
+ * @since ```feedzai.next.release```
+ */
+
+const isUndefined = <GenericValue>(value: GenericValue): boolean => typeof value === 'undefined';
+const isNull = <GenericValue>(value: GenericValue): boolean => typeof value === null;
+
+/**
+ * Checks if a certain value is `null` or `undefined`.
+ *
+ * @example
+ *
+ * isNil(3) // false
+ * isNil(null) // true
+ * isNil(undefined) // true
+ *
+ * @export
+ * @template GenericValue
+ * @param {GenericValue} value
+ * @returns {boolean} result
+ */
+export const isNil = <GenericValue>(value: GenericValue): boolean => isUndefined(value) || isNull(value);
+

--- a/src/hooks/useAutoId.ts
+++ b/src/hooks/useAutoId.ts
@@ -11,7 +11,8 @@
  * @author João Dias <joao.dias@feedzai.com>
  * @since 1.1.0
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { makeId } from "../helpers";
 import { useSafeLayoutEffect } from "./useSafeLayoutEffect";
 
 let hasHydrated = false;
@@ -30,11 +31,28 @@ const generateIncrementalId = () => ++id;
  * The returned ID will initially be `null` and will update after a
  * component mounts. Users may need to supply their own ID if they need
  * consistent values for SSR.
+ *
+ * @example
+ *
+ * // Generating an id (no pre-defined id and no prefix)
+ * const id1 = useAutoId(); // will return, for example, "0"
+ *
+ * // Using a pre-defined id (no prefix)
+ * const id2 = useAutoId("8e88aa2e-e6a8") // will return "8e88aa2e-e6a8"
+ *
+ * // Using a prefix with an auto-generated id (no pre-defined id)
+ * const id3 = useAutoId(undefined, "fdz-prefix") // will return, for example, "fdz-prefix--10"
+ *
+ * // Using a prefix with a pre-defined id
+ * const id4 = useAutoId("6949d175", "fdz-js-checkbox") // will return "fdz-js-checkbox--6949d175"
+ *
+ * @param {string | null | undefined} customId - You can pass an previously defined value
+ * and that value will be used as the value of the returned id.
+ * @param {string | undefined} prefix - If necessary, you can prepend a generated id with a prefix.
+ * @returns {string | undefined} an auto/self-generated id with a possible prefix
  */
-function useAutoId(customId: string): string;
-function useAutoId(customId: string | undefined): string | undefined;
-function useAutoId(customId?: null): string | undefined;
-function useAutoId(customId?: string | null) {
+function useAutoId(customId?: string | null, prefix?: string): string | undefined {
+	const { current: idPrefix } = useRef(prefix);
 	const initialId = customId || (hasHydrated ? generateIncrementalId() : null);
 	const [id, setId] = useState(initialId);
 
@@ -45,7 +63,6 @@ function useAutoId(customId?: string | null) {
 		if (id === null) {
 			setId(generateIncrementalId());
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, []);
 
 	/*
@@ -59,7 +76,17 @@ function useAutoId(customId?: string | null) {
 		}
 	}, []);
 
-	return id != null ? String(id) : undefined;
+	const finalId = useMemo(() => {
+		if (!id) {
+			return undefined;
+		}
+
+		const finalId = String(id);
+
+		return prefix ? makeId(prefix, finalId) : finalId;
+	}, [id, idPrefix]);
+
+	return finalId;
 }
 
 export { useAutoId };

--- a/test/hooks/useAutoId.test.tsx
+++ b/test/hooks/useAutoId.test.tsx
@@ -12,12 +12,12 @@
  * @since 1.1.0
  */
 import React from "react";
+import "@testing-library/jest-dom/extend-expect";
 import { render, screen } from "@testing-library/react";
 import { useAutoId } from "../../src/hooks/useAutoId";
 
-function DemoComponent() {
-	const value = null;
-	const firstId = useAutoId(value);
+function DemoComponent({ value = null, prefix }: { value?: string | null; prefix?: string }) {
+	const firstId = useAutoId(value, prefix);
 	const secondId = useAutoId();
 	return (
 		<div>
@@ -27,8 +27,14 @@ function DemoComponent() {
 	);
 }
 
-function FallbackDemo() {
-	const id = useAutoId("fdz-fallback-id");
+function FallbackDemo({
+	value = "fdz-fallback-id",
+	prefix,
+}: {
+	value?: string | null;
+	prefix?: string;
+}) {
+	const id = useAutoId(value, prefix);
 	return <h1 id={id}>Feedzai</h1>;
 }
 
@@ -41,8 +47,21 @@ describe("useAutoId", () => {
 		expect(idTwo).not.toEqual(idOne);
 	});
 
+	it("should generate a prefixed unique ID value", () => {
+		const expected = "fdz-js-a-prefix";
+		render(<DemoComponent value={undefined} prefix={expected} />);
+		const idOne = screen.getByText("A paragraph").id;
+
+		expect(idOne).toContain(expected);
+	});
+
 	it("uses a fallback ID", () => {
 		render(<FallbackDemo />);
 		expect(screen.getByText("Feedzai").id).toEqual("fdz-fallback-id");
+	});
+
+	it("should return a prefixed fallback ID", () => {
+		render(<FallbackDemo prefix="fdz-js-prefix" value="423696e5" />);
+		expect(screen.getByText("Feedzai").id).toEqual("fdz-js-prefix--423696e5");
 	});
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,6 +219,13 @@
     resolve "^1.14.2"
     semver "^6.1.2"
 
+"@babel/helper-environment-visitor@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz#ff484094a839bde9d89cd63cba017d7aae80ecd7"
+  integrity sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-explode-assignable-expression@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.14.5.tgz#8aa72e708205c7bb643e45c73b4386cdf2a1f645"
@@ -450,6 +457,11 @@
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
+
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
 
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
@@ -1449,6 +1461,14 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
+"@babel/types@^7.16.7":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
+    to-fast-properties "^2.0.0"
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -2296,10 +2316,10 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/jest@27.0.2":
-  version "27.0.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.0.2.tgz#ac383c4d4aaddd29bbf2b916d8d105c304a5fcd7"
-  integrity sha512-4dRxkS/AFX0c5XW6IPMNOydLn2tEhNhJV7DnYK+0bjoJZ+QTmfucBlihX7aoEsh/ocYtkLC73UbnBXBXIxsULA==
+"@types/jest@^27.4.0":
+  version "27.4.0"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.0.tgz#037ab8b872067cae842a320841693080f9cb84ed"
+  integrity sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==
   dependencies:
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
@@ -3850,15 +3870,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001251:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
-
-caniuse-lite@^1.0.30001264, caniuse-lite@^1.0.30001265:
-  version "1.0.30001271"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz#0dda0c9bcae2cf5407cd34cac304186616cc83e8"
-  integrity sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001251, caniuse-lite@^1.0.30001264, caniuse-lite@^1.0.30001265:
+  version "1.0.30001312"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
+  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3884,7 +3899,7 @@ chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.4.2:
+chalk@^2.0.0:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -4702,11 +4717,6 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-dateformat@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
-  integrity sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==
-
 dayjs@1.10.7:
   version "1.10.7"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
@@ -4934,11 +4944,6 @@ diff@^1.3.2:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-1.4.0.tgz#7f28d2eb9ee7b15a97efd89ce63dcfdaa3ccbabf"
   integrity sha1-fyjS657nsVqX79ic5j3P2qPMur8=
-
-diff@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
-  integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -5378,7 +5383,7 @@ escalade@^3.1.1:
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
-escape-html@^1.0.3, escape-html@~1.0.3:
+escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
@@ -6167,15 +6172,6 @@ fs-extra@^4.0.3:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0, fs-extra@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
-  integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^4.0.0"
-    universalify "^0.1.0"
-
 fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
@@ -6208,11 +6204,6 @@ fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
-
-fsu@^1.0.2:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/fsu/-/fsu-1.1.1.tgz#bd36d3579907c59d85b257a75b836aa9e0c31834"
-  integrity sha512-xQVsnjJ/5pQtcKh+KjUoZGzVWn4uNkchxTF6Lwjr4Gf7nQr8fmUfhKJ62zE77+xQg9xnxi5KUps7XGs+VC986A==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -6338,7 +6329,7 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.3, glob@^7.1.0, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.7"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
   integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
@@ -6930,11 +6921,6 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 invariant@^2.2.2, invariant@^2.2.3:
   version "2.2.4"
@@ -8043,7 +8029,7 @@ json-stable-stringify@~0.0.0:
   dependencies:
     jsonify "~0.0.0"
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
@@ -8320,26 +8306,6 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
-
-lodash.isempty@^4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/lodash.isempty/-/lodash.isempty-4.4.0.tgz#6f86cbedd8be4ec987be9aaf33c9684db1b31e7e"
-  integrity sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=
-
-lodash.isfunction@^3.0.8, lodash.isfunction@^3.0.9:
-  version "3.0.9"
-  resolved "https://registry.yarnpkg.com/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz#06de25df4db327ac931981d1bdb067e5af68d051"
-  integrity sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==
-
-lodash.isobject@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash.isobject/-/lodash.isobject-3.0.2.tgz#3c8fb8d5b5bf4bf90ae06e14f2a530a4ed935e1d"
-  integrity sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0=
-
-lodash.isstring@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
-  integrity sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=
 
 lodash.memoize@4.x, lodash.memoize@^4.1.2:
   version "4.1.2"
@@ -8631,7 +8597,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -8660,50 +8626,6 @@ mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mochawesome-merge@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/mochawesome-merge/-/mochawesome-merge-4.2.0.tgz#970ea141165039bfdd6772b1232a1ef6ba99af1a"
-  integrity sha512-FSMzagh+8hTShhFXdBLE4/zS2WALcDruoD0bmtiwHEjfyQszR/iEGFTgbuM5ewA5At3qeSGwGsT0k2Stt64NdQ==
-  dependencies:
-    fs-extra "^7.0.1"
-    glob "^7.1.6"
-    uuid "^3.3.2"
-    yargs "^15.3.1"
-
-mochawesome-report-generator@5.2.0, mochawesome-report-generator@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/mochawesome-report-generator/-/mochawesome-report-generator-5.2.0.tgz#ffd29f8d610863e48e63c15c4e83b5689d8dbd04"
-  integrity sha512-DDY/3jSkM/VrWy0vJtdYOf6qBLdaPaLcI7rQmBVbnclIX7AKniE1Rhz3T/cMT/7u54W5EHNo1z84z7efotq/Eg==
-  dependencies:
-    chalk "^2.4.2"
-    dateformat "^3.0.2"
-    escape-html "^1.0.3"
-    fs-extra "^7.0.0"
-    fsu "^1.0.2"
-    lodash.isfunction "^3.0.8"
-    opener "^1.5.2"
-    prop-types "^15.7.2"
-    tcomb "^3.2.17"
-    tcomb-validation "^3.3.0"
-    validator "^10.11.0"
-    yargs "^13.2.2"
-
-mochawesome@6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/mochawesome/-/mochawesome-6.3.1.tgz#9dc1e73165f4686a6f29c382d36b8cf3cd6a6e9c"
-  integrity sha512-G2J7Le8ap+0222otJQEUVFs7RYzphiIk21NzaBZE2dbyHJ2+9aai+V2cV7lreEKigDpwQ+SXeiiBH9KQlrkaAQ==
-  dependencies:
-    chalk "^4.1.0"
-    diff "^5.0.0"
-    json-stringify-safe "^5.0.1"
-    lodash.isempty "^4.4.0"
-    lodash.isfunction "^3.0.9"
-    lodash.isobject "^3.0.2"
-    lodash.isstring "^4.0.1"
-    mochawesome-report-generator "^5.2.0"
-    strip-ansi "^6.0.0"
-    uuid "^8.3.2"
 
 mocked-env@1.3.2:
   version "1.3.2"
@@ -9102,11 +9024,6 @@ open@^8.2.1:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-opener@^1.5.2:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
-  integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
 
 opn@^5.5.0:
   version "5.5.0"
@@ -10207,13 +10124,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
-  dependencies:
-    resolve "^1.1.6"
-
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -10410,7 +10320,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.1.4, resolve@^1.1.6, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
+resolve@^1.1.4, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.19.0, resolve@^1.20.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -10815,23 +10725,6 @@ shell-quote@^1.4.2, shell-quote@^1.6.1:
   version "1.7.2"
   resolved "https://registry.yarnpkg.com/shell-quote/-/shell-quote-1.7.2.tgz#67a7d02c76c9da24f99d20808fcaded0e0e04be2"
   integrity sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==
-
-shelljs@^0.8.4:
-  version "0.8.4"
-  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.4.tgz#de7684feeb767f8716b326078a8a00875890e3c2"
-  integrity sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
-shx@0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/shx/-/shx-0.3.3.tgz#681a88c7c10db15abe18525349ed474f0f1e7b9f"
-  integrity sha512-nZJ3HFWVoTSyyB+evEKjJ1STiixGztlqwKLTUNV5KqMWtGey9fTd4KU1gdZ1X9BV6215pswQ/Jew9NsuS/fNDA==
-  dependencies:
-    minimist "^1.2.3"
-    shelljs "^0.8.4"
 
 side-channel@^1.0.4:
   version "1.0.4"
@@ -11432,18 +11325,6 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
 
-tcomb-validation@^3.3.0:
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/tcomb-validation/-/tcomb-validation-3.4.1.tgz#a7696ec176ce56a081d9e019f8b732a5a8894b65"
-  integrity sha512-urVVMQOma4RXwiVCa2nM2eqrAomHROHvWPuj6UkDGz/eb5kcy0x6P0dVt6kzpUZtYMNoAqJLWmz1BPtxrtjtrA==
-  dependencies:
-    tcomb "^3.0.0"
-
-tcomb@^3.0.0, tcomb@^3.2.17:
-  version "3.2.29"
-  resolved "https://registry.yarnpkg.com/tcomb/-/tcomb-3.2.29.tgz#32404fe9456d90c2cf4798682d37439f1ccc386c"
-  integrity sha512-di2Hd1DB2Zfw6StGv861JoAF5h/uQVu/QJp2g8KVbtfKnoHdBQl5M32YWq6mnSYBQ1vFFrns5B1haWJL7rKaOQ==
-
 terminal-link@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/terminal-link/-/terminal-link-2.1.1.tgz#14a64a27ab3c0df933ea546fba55f2d078edc994"
@@ -11948,11 +11829,6 @@ v8-to-istanbul@^8.1.0:
     convert-source-map "^1.6.0"
     source-map "^0.7.3"
 
-validator@^10.11.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.11.0.tgz#003108ea6e9a9874d31ccc9e5006856ccd76b228"
-  integrity sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw==
-
 variable-diff@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/variable-diff/-/variable-diff-1.1.0.tgz#d2bd5c66db76c13879d96e6a306edc989df978da"
@@ -12358,7 +12234,7 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
-yargs@^13.2.2, yargs@^13.3.2:
+yargs@^13.3.2:
   version "13.3.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-13.3.2.tgz#ad7ffefec1aa59565ac915f82dccb38a9c31a2dd"
   integrity sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
@@ -12374,7 +12250,7 @@ yargs@^13.2.2, yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
-yargs@^15.0.2, yargs@^15.3.1:
+yargs@^15.0.2:
   version "15.4.1"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
   integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==


### PR DESCRIPTION
## Because:
- We are having to use the `makeId´ multiple times after generating an id.
- The coverage wasn't being properly merged after running jest, cypress component testing and cypress integration tests

## This Commit:
- Adds support for an optional `prefix` argument on the `useAutoId` custom-hook. This, when passed as a string, prepends any id (generated or pre-defined) with that defined prefix. So, for `useAutoId(undefined, "fdz-js-custom-prefix")` we would have the result of `fdz-js-custom-prefix--0` and for `useAutoId("a-pre-defined-id", "fdz-js-custom-prefix")` the result would be "fdz-js-custom-prefix--a-pre-defined-id".
- Fixes the coverage report
- Also adds the support for non-scrolling focus when using the `useFocus` custom-hook (from the roving tabindex component).
- Also adds a new helper `isNil` which is a resemblance helper from `lodash`. But, since we're not using lodash here (to make the side-effects as low as possible), this is a vanilla implementation.

## Breaking Changes:
None.