### PR TITLE
fix(focus-manager): Move activeScope and scope to window object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@feedzai/react-a11y-tools",
 	"author": "Feedzai",
-	"version": "1.4.0",
+	"version": "1.4.1-rc-window.0",
 	"license": "MIT",
 	"main": "dist/index.cjs.js",
 	"typings": "dist/index.d.ts",

--- a/src/components/focus-manager/helpers/state.ts
+++ b/src/components/focus-manager/helpers/state.ts
@@ -1,0 +1,5 @@
+export default function createFocusManagerState() {
+	if (!window.__react_a11y_tools_scopes__) {
+		window.__react_a11y_tools_scopes__ = new Set();
+	}
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -14,8 +14,8 @@
  */
 declare module "*.css";
 
-declare interface Navigator extends NavigatorUA { }
-declare interface WorkerNavigator extends NavigatorUA { }
+declare interface Navigator extends NavigatorUA {}
+declare interface WorkerNavigator extends NavigatorUA {}
 
 // https://wicg.github.io/ua-client-hints/#navigatorua
 declare interface NavigatorUA {
@@ -54,4 +54,9 @@ interface UALowEntropyJSON {
 interface NavigatorUAData extends UALowEntropyJSON {
 	getHighEntropyValues(hints: string[]): Promise<UADataValues>;
 	toJSON(): UALowEntropyJSON;
+}
+
+interface Window {
+	__react_a11y_tools_activeScope__: RefObject<HTMLElement[]> | null;
+	__react_a11y_tools_scopes__: Set<RefObject<HTMLElement[]>>;
 }


### PR DESCRIPTION
### Because

Since we have `react-a11y-tools` imported in multiple projects (Escudo and UI Kit) when these libraries access these two objects their instance is not the same (because they are not part of the global scope) and these cause problems managing the element that should receive focus.

### This commit

Moves `activeScope` and `scope` from local variables to the window object making sure that different instances of the FocusManager use the same instance of these objects.