### PR TITLE
ci(semantic-release): adds support for publish packages to npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,69 @@
 name: CI
-on: [push]
+on:
+  - push
+  - pull_request
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 jobs:
-  build:
-    name: Build, lint, and test on Node ${{ matrix.node }} and ${{ matrix.os }}
-
+  quality:
+    name: Unit, component and e2e tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node: ["18.x", "20.x"]
-        os: [ubuntu-latest]
-
+        node-version:
+          - 18.x
+          - 20.x
+        os:
+          - ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@v2
-
-      - name: Use Node ${{ matrix.node }}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - name: Using node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
-
-      - name: Install deps and build (with cache)
-        uses: bahmutov/npm-install@v1
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Test Components
-        run: npm run test:ci
-
-      - name: Build
-        run: npm run build
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run test:ci
+  docs:
+    name: Deploy documentation
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - quality
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          cache: npm
+      - name: Building docs...
+        run: npm ci
+      - name: Build website
+        run: npm run docs:build
+      - name: Deploying docs...
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./documentation/build
+          user_name: github-actions[bot]
+          user_email: 41898282+github-actions[bot]@users.noreply.github.com
+  package_release:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    if: ${{ github.ref == 'refs/heads/main' }}
+    needs:
+      - quality
+    strategy:
+      matrix:
+        node-version: ["20.x"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Using node ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm run semantic-release

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -2,7 +2,12 @@ name: size
 on: [pull_request]
 jobs:
   size:
-    runs-on: ubuntu-latest
+    name: Checking bundle size
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: ["18.x"]
+        os: [ubuntu-latest]
     env:
       CI_JOB_NUMBER: 1
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,31 @@
+{
+	"branches": [
+		"main",
+		{
+			"name": "next",
+			"prerelease": true
+		}
+	],
+	"debug": true,
+	"ci": true,
+	"dryRun": false,
+	"plugins": [
+		["@semantic-release/commit-analyzer"],
+		["@semantic-release/release-notes-generator"],
+		[
+			"@semantic-release/changelog",
+			{
+				"changelogFile": "CHANGELOG.md"
+			}
+		],
+		"@semantic-release/npm",
+		"@semantic-release/github",
+		[
+			"@semantic-release/git",
+			{
+				"assets": ["package.json", "package-lock.json", "./CHANGELOG.md"],
+				"message": "chore(release): set `package.json` to ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+			}
+		]
+	]
+}

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+const COMMITLINT_CONFIG = {
+	extends: ["@commitlint/config-conventional"],
+};
+
+module.exports = COMMITLINT_CONFIG;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,12 @@
 			"devDependencies": {
 				"@cypress/code-coverage": "3.12.24",
 				"@jtmdias/merge-coverage": "^1.1.0",
+				"@semantic-release/changelog": "^6.0.3",
+				"@semantic-release/commit-analyzer": "^11.1.0",
+				"@semantic-release/git": "^10.0.1",
+				"@semantic-release/github": "^9.2.6",
+				"@semantic-release/npm": "^11.0.2",
+				"@semantic-release/release-notes-generator": "^12.1.0",
 				"@size-limit/preset-small-lib": "11.0.2",
 				"@testing-library/cypress": "10.0.1",
 				"@testing-library/jest-dom": "6.4.2",
@@ -51,6 +57,7 @@
 				"react-router": "^6.22.1",
 				"react-router-dom": "^6.22.1",
 				"sass": "1.71.1",
+				"semantic-release": "^22.0.12",
 				"size-limit": "11.0.2",
 				"start-server-and-test": "2.0.3",
 				"typescript": "5.3.3",
@@ -3504,6 +3511,152 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
+		"node_modules/@octokit/auth-token": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+			"integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/core": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.1.0.tgz",
+			"integrity": "sha512-BDa2VAMLSh3otEiaMJ/3Y36GU4qf6GI+VivQ/P41NC6GHcdxpKlqV0ikSZ5gdQsmS3ojXeRx5vasgNTinF0Q4g==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/auth-token": "^4.0.0",
+				"@octokit/graphql": "^7.0.0",
+				"@octokit/request": "^8.0.2",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0",
+				"before-after-hook": "^2.2.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/endpoint": {
+			"version": "9.0.4",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.4.tgz",
+			"integrity": "sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^12.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/graphql": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.0.2.tgz",
+			"integrity": "sha512-OJ2iGMtj5Tg3s6RaXH22cJcxXRi7Y3EBqbHTBRq+PQAqfaS8f/236fUrWhfSn8P4jovyzqucxme7/vWSSZBX2Q==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/request": "^8.0.1",
+				"@octokit/types": "^12.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/openapi-types": {
+			"version": "20.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
+			"integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
+			"dev": true
+		},
+		"node_modules/@octokit/plugin-paginate-rest": {
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.0.tgz",
+			"integrity": "sha512-NKi0bJEZqOSbBLMv9kdAcuocpe05Q2xAXNLTGi0HN2GSMFJHNZuSoPNa0tcQFTOFCKe+ZaYBZ3lpXh1yxgUDCA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^12.6.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-retry": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-retry/-/plugin-retry-6.0.1.tgz",
+			"integrity": "sha512-SKs+Tz9oj0g4p28qkZwl/topGcb0k0qPNX/i7vBKmDsjoeqnVfFUquqrE/O9oJY7+oLzdCtkiWSXLpLjvl6uog==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": ">=5"
+			}
+		},
+		"node_modules/@octokit/plugin-throttling": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/plugin-throttling/-/plugin-throttling-8.2.0.tgz",
+			"integrity": "sha512-nOpWtLayKFpgqmgD0y3GqXafMFuKcA4tRPZIfu7BArd2lEZeb1988nhWhwx4aZWmjDmUfdgVf7W+Tt4AmvRmMQ==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^12.2.0",
+				"bottleneck": "^2.15.3"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"@octokit/core": "^5.0.0"
+			}
+		},
+		"node_modules/@octokit/request": {
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.2.0.tgz",
+			"integrity": "sha512-exPif6x5uwLqv1N1irkLG1zZNJkOtj8bZxuVHd71U5Ftuxf2wGNvAJyNBcPbPC+EBzwYEbBDdSFb8EPcjpYxPQ==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/endpoint": "^9.0.0",
+				"@octokit/request-error": "^5.0.0",
+				"@octokit/types": "^12.0.0",
+				"universal-user-agent": "^6.0.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/request-error": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.0.1.tgz",
+			"integrity": "sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/types": "^12.0.0",
+				"deprecation": "^2.0.0",
+				"once": "^1.4.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@octokit/types": {
+			"version": "12.6.0",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
+			"integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/openapi-types": "^20.0.0"
+			}
+		},
 		"node_modules/@oozcitak/dom": {
 			"version": "1.15.10",
 			"resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
@@ -3550,6 +3703,47 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/@pnpm/config.env-replace": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
+			"integrity": "sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+			"integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "4.2.10"
+			},
+			"engines": {
+				"node": ">=12.22.0"
+			}
+		},
+		"node_modules/@pnpm/network.ca-file/node_modules/graceful-fs": {
+			"version": "4.2.10",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true
+		},
+		"node_modules/@pnpm/npm-conf": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz",
+			"integrity": "sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==",
+			"dev": true,
+			"dependencies": {
+				"@pnpm/config.env-replace": "^1.1.0",
+				"@pnpm/network.ca-file": "^1.0.1",
+				"config-chain": "^1.1.11"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -3877,6 +4071,618 @@
 				"sprintf-js": "~1.0.2"
 			}
 		},
+		"node_modules/@semantic-release/changelog": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.3.tgz",
+			"integrity": "sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==",
+			"dev": true,
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash": "^4.17.4"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/changelog/node_modules/fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@semantic-release/commit-analyzer": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-11.1.0.tgz",
+			"integrity": "sha512-cXNTbv3nXR2hlzHjAMgbuiQVtvWHTlwwISt60B+4NZv01y/QRY7p2HcJm8Eh2StzcTJoNnflvKjHH/cjFS7d5g==",
+			"dev": true,
+			"dependencies": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"import-from-esm": "^1.0.3",
+				"lodash-es": "^4.17.21",
+				"micromatch": "^4.0.2"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/error": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+			"integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/@semantic-release/git": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/git/-/git-10.0.1.tgz",
+			"integrity": "sha512-eWrx5KguUcU2wUPaO6sfvZI0wPafUKAMNC18aXY4EnNcrZL86dEmpNVnC9uMpGZkmZJ9EfCVJBQx4pV4EMGT1w==",
+			"dev": true,
+			"dependencies": {
+				"@semantic-release/error": "^3.0.0",
+				"aggregate-error": "^3.0.0",
+				"debug": "^4.0.0",
+				"dir-glob": "^3.0.0",
+				"execa": "^5.0.0",
+				"lodash": "^4.17.4",
+				"micromatch": "^4.0.0",
+				"p-reduce": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.17"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=18.0.0"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/execa": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+			"integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^6.0.0",
+				"human-signals": "^2.1.0",
+				"is-stream": "^2.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^4.0.1",
+				"onetime": "^5.1.2",
+				"signal-exit": "^3.0.3",
+				"strip-final-newline": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/git/node_modules/human-signals": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+			"integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/@semantic-release/github": {
+			"version": "9.2.6",
+			"resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-9.2.6.tgz",
+			"integrity": "sha512-shi+Lrf6exeNZF+sBhK+P011LSbhmIAoUEgEY6SsxF8irJ+J2stwI5jkyDQ+4gzYyDImzV6LCKdYB9FXnQRWKA==",
+			"dev": true,
+			"dependencies": {
+				"@octokit/core": "^5.0.0",
+				"@octokit/plugin-paginate-rest": "^9.0.0",
+				"@octokit/plugin-retry": "^6.0.0",
+				"@octokit/plugin-throttling": "^8.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"debug": "^4.3.4",
+				"dir-glob": "^3.0.1",
+				"globby": "^14.0.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.0",
+				"issue-parser": "^6.0.0",
+				"lodash-es": "^4.17.21",
+				"mime": "^4.0.0",
+				"p-filter": "^4.0.0",
+				"url-join": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/agent-base": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+			"integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/clean-stack": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/globby": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-14.0.1.tgz",
+			"integrity": "sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==",
+			"dev": true,
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^2.1.0",
+				"fast-glob": "^3.3.2",
+				"ignore": "^5.2.4",
+				"path-type": "^5.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/https-proxy-agent": {
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.4.tgz",
+			"integrity": "sha512-wlwpilI7YdjSkWaQ/7omYBMTliDcmCN8OLihO6I9B86g06lMyAoqgoDpV0XqoaPOKj+0DIdAvnsWfyAAhmimcg==",
+			"dev": true,
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/path-type": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-5.0.0.tgz",
+			"integrity": "sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/github/node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm": {
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-11.0.2.tgz",
+			"integrity": "sha512-owtf3RjyPvRE63iUKZ5/xO4uqjRpVQDUB9+nnXj0xwfIeM9pRl+cG+zGDzdftR4m3f2s4Wyf3SexW+kF5DFtWA==",
+			"dev": true,
+			"dependencies": {
+				"@semantic-release/error": "^4.0.0",
+				"aggregate-error": "^5.0.0",
+				"execa": "^8.0.0",
+				"fs-extra": "^11.0.0",
+				"lodash-es": "^4.17.21",
+				"nerf-dart": "^1.0.0",
+				"normalize-url": "^8.0.0",
+				"npm": "^10.0.0",
+				"rc": "^1.2.8",
+				"read-pkg": "^9.0.0",
+				"registry-auth-token": "^5.0.0",
+				"semver": "^7.1.2",
+				"tempy": "^3.0.0"
+			},
+			"engines": {
+				"node": "^18.17 || >=20"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/clean-stack": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/fs-extra": {
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+			"integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@semantic-release/npm/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/@semantic-release/release-notes-generator": {
+			"version": "12.1.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-12.1.0.tgz",
+			"integrity": "sha512-g6M9AjUKAZUZnxaJZnouNBeDNTCUrJ5Ltj+VJ60gJeDaRRahcHsry9HW8yKrnKkKNkx5lbWiEP1FPMqVNQz8Kg==",
+			"dev": true,
+			"dependencies": {
+				"conventional-changelog-angular": "^7.0.0",
+				"conventional-changelog-writer": "^7.0.0",
+				"conventional-commits-filter": "^4.0.0",
+				"conventional-commits-parser": "^5.0.0",
+				"debug": "^4.0.0",
+				"get-stream": "^7.0.0",
+				"import-from-esm": "^1.0.3",
+				"into-stream": "^7.0.0",
+				"lodash-es": "^4.17.21",
+				"read-pkg-up": "^11.0.0"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			},
+			"peerDependencies": {
+				"semantic-release": ">=20.1.0"
+			}
+		},
+		"node_modules/@semantic-release/release-notes-generator/node_modules/get-stream": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-7.0.1.tgz",
+			"integrity": "sha512-3M8C1EOFN6r8AMUhwUAACIoXZJEOufDU5+0gFFN5uNs6XYOralD2Pqkl7m046va6x77FwposWXbAhPPIOus7mQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@sideway/address": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -3903,6 +4709,18 @@
 			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
 			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
 			"dev": true
+		},
+		"node_modules/@sindresorhus/is": {
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+			"integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/is?sponsor=1"
+			}
 		},
 		"node_modules/@sindresorhus/merge-streams": {
 			"version": "2.3.0",
@@ -4611,6 +5429,12 @@
 			"dependencies": {
 				"undici-types": "~5.26.4"
 			}
+		},
+		"node_modules/@types/normalize-package-data": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+			"dev": true
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.2",
@@ -5881,6 +6705,12 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/argv-formatter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/argv-formatter/-/argv-formatter-1.0.0.tgz",
+			"integrity": "sha512-F2+Hkm9xFaRg+GkaNnbwXNDV5O6pnCFEmqyhvfC/Ic5LbgOWjJh3L+mN/s91rxVL3znE7DYVpW0GJFT+4YBgWw==",
+			"dev": true
+		},
 		"node_modules/aria-query": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
@@ -5905,6 +6735,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/array-ify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
+			"integrity": "sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==",
+			"dev": true
 		},
 		"node_modules/array-includes": {
 			"version": "3.1.7",
@@ -6427,6 +7263,12 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"node_modules/before-after-hook": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+			"integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+			"dev": true
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -6446,6 +7288,12 @@
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
 			"integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+			"dev": true
+		},
+		"node_modules/bottleneck": {
+			"version": "2.19.5",
+			"resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+			"integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
 			"dev": true
 		},
 		"node_modules/brace-expansion": {
@@ -6752,8 +7600,6 @@
 			"resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -6920,8 +7766,6 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
 			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"string-width": "^4.2.0",
 				"strip-ansi": "^6.0.1",
@@ -7027,6 +7871,16 @@
 			"integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
 			"dev": true
 		},
+		"node_modules/compare-func": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+			"integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
+			"dev": true,
+			"dependencies": {
+				"array-ify": "^1.0.0",
+				"dot-prop": "^5.1.0"
+			}
+		},
 		"node_modules/computeds": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/computeds/-/computeds-0.0.1.tgz",
@@ -7039,6 +7893,22 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true
 		},
+		"node_modules/config-chain": {
+			"version": "1.1.13",
+			"resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+			"integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+			"dev": true,
+			"dependencies": {
+				"ini": "^1.3.4",
+				"proto-list": "~1.2.1"
+			}
+		},
+		"node_modules/config-chain/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
 		"node_modules/content-type": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -7046,6 +7916,98 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/conventional-changelog-angular": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
+			"integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
+			"dev": true,
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/conventional-changelog-writer": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-7.0.1.tgz",
+			"integrity": "sha512-Uo+R9neH3r/foIvQ0MKcsXkX642hdm9odUp7TqgFS7BsalTcjzRlIfWZrZR1gbxOozKucaKt5KAbjW8J8xRSmA==",
+			"dev": true,
+			"dependencies": {
+				"conventional-commits-filter": "^4.0.0",
+				"handlebars": "^4.7.7",
+				"json-stringify-safe": "^5.0.1",
+				"meow": "^12.0.1",
+				"semver": "^7.5.2",
+				"split2": "^4.0.0"
+			},
+			"bin": {
+				"conventional-changelog-writer": "cli.mjs"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/conventional-changelog-writer/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-changelog-writer/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/conventional-changelog-writer/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/conventional-commits-filter": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-4.0.0.tgz",
+			"integrity": "sha512-rnpnibcSOdFcdclpFwWa+pPlZJhXE7l+XK04zxhbWrhgpR96h33QLz8hITTXbcYICxVr3HZFtbtUAQ+4LdBo9A==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/conventional-commits-parser": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-5.0.0.tgz",
+			"integrity": "sha512-ZPMl0ZJbw74iS9LuX9YIAiW8pfM5p3yh2o/NbXHbkFuZzY5jvdi5jFycEOkmBW5H5I7nA+D6f3UcsCLP2vvSEA==",
+			"dev": true,
+			"dependencies": {
+				"is-text-path": "^2.0.0",
+				"JSONStream": "^1.3.5",
+				"meow": "^12.0.1",
+				"split2": "^4.0.0"
+			},
+			"bin": {
+				"conventional-commits-parser": "cli.mjs"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/convert-source-map": {
@@ -7131,6 +8093,33 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypto-random-string": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
+			"integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/crypto-random-string/node_modules/type-fest": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/css.escape": {
@@ -7473,6 +8462,15 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/deep-extend": {
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -7547,6 +8545,12 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
+		},
+		"node_modules/deprecation": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+			"integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+			"dev": true
 		},
 		"node_modules/dequal": {
 			"version": "2.0.3",
@@ -7643,11 +8647,41 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/dot-prop": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+			"integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+			"dev": true,
+			"dependencies": {
+				"is-obj": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/dot-prop/node_modules/is-obj": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/duplexer": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
 			"integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
 			"dev": true
+		},
+		"node_modules/duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "^2.0.2"
+			}
 		},
 		"node_modules/ecc-jsbn": {
 			"version": "0.1.2",
@@ -7700,6 +8734,12 @@
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
 			"dev": true
 		},
+		"node_modules/emojilib": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+			"integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+			"dev": true
+		},
 		"node_modules/end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -7745,6 +8785,153 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-ci": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/env-ci/-/env-ci-10.0.0.tgz",
+			"integrity": "sha512-U4xcd/utDYFgMh0yWj07R1H6L5fwhVbmxBCpnL0DbVSDZVnsC82HONw0wxtxNkIAcua3KtbomQvIk5xFZGAQJw==",
+			"dev": true,
+			"dependencies": {
+				"execa": "^8.0.0",
+				"java-properties": "^1.0.2"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
+		},
+		"node_modules/env-ci/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/env-ci/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/env-ci/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/env-ci/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/env-ci/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/error-ex": {
@@ -8878,6 +10065,33 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/find-up-simple": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.0.tgz",
+			"integrity": "sha512-q7Us7kcjj2VMePAa02hDAF6d+MzsdsAWEwYyOpwUtlerRBkOEPBCRZrAV4XfcSN8fHAgaD0hP7miwoay6DCprw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-versions": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+			"integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
+			"dev": true,
+			"dependencies": {
+				"semver-regex": "^4.0.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/flat": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -8991,6 +10205,16 @@
 			"resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
 			"integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
 			"dev": true
+		},
+		"node_modules/from2": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+			"integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.0"
+			}
 		},
 		"node_modules/fromentries": {
 			"version": "1.3.2",
@@ -9206,6 +10430,29 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"node_modules/git-log-parser": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/git-log-parser/-/git-log-parser-1.2.0.tgz",
+			"integrity": "sha512-rnCVNfkTL8tdNryFuaY0fYiBWEBcgF748O6ZI61rslBvr2o7U65c2/6npCRqH40vuAhtgtDiqLTJjBVdrejCzA==",
+			"dev": true,
+			"dependencies": {
+				"argv-formatter": "~1.0.0",
+				"spawn-error-forwarder": "~1.0.0",
+				"split2": "~1.0.0",
+				"stream-combiner2": "~1.1.1",
+				"through2": "~2.0.0",
+				"traverse": "~0.6.6"
+			}
+		},
+		"node_modules/git-log-parser/node_modules/split2": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
+			"integrity": "sha512-NKywug4u4pX/AZBB1FCPzZ6/7O+Xhz1qMVbzTvvKvikjO99oPN87SkK08mEY9P63/5lWjK+wgOOgApnTg5r6qg==",
+			"dev": true,
+			"dependencies": {
+				"through2": "~2.0.0"
+			}
+		},
 		"node_modules/glob": {
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -9328,6 +10575,27 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
+		"node_modules/handlebars": {
+			"version": "4.7.8",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.2",
+				"source-map": "^0.6.1",
+				"wordwrap": "^1.0.0"
+			},
+			"bin": {
+				"handlebars": "bin/handlebars"
+			},
+			"engines": {
+				"node": ">=0.4.7"
+			},
+			"optionalDependencies": {
+				"uglify-js": "^3.1.4"
+			}
+		},
 		"node_modules/has-bigints": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -9441,6 +10709,39 @@
 			"dev": true,
 			"bin": {
 				"he": "bin/he"
+			}
+		},
+		"node_modules/hook-std": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+			"integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/hosted-git-info": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+			"integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/hosted-git-info/node_modules/lru-cache": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+			"integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+			"dev": true,
+			"engines": {
+				"node": "14 || >=16.14"
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
@@ -9637,6 +10938,19 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/import-from-esm": {
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/import-from-esm/-/import-from-esm-1.3.3.tgz",
+			"integrity": "sha512-U3Qt/CyfFpTUv6LOP2jRTLYjphH6zg3okMfHbyqRa/W2w6hr8OsJWVggNlR4jxuojQy81TgTJTxgSkyoteRGMQ==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"import-meta-resolve": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=16.20"
+			}
+		},
 		"node_modules/import-lazy": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
@@ -9681,6 +10995,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/import-meta-resolve": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.0.0.tgz",
+			"integrity": "sha512-okYUR7ZQPH+efeuMJGlq4f8ubUgO50kByRPyt/Cy1Io4PSRsPjxME+YlVaCOx+NIToW7hCsZNFJyTPFFKepRSA==",
+			"dev": true,
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -9697,6 +11021,18 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/index-to-position": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-0.1.2.tgz",
+			"integrity": "sha512-MWDKS3AS1bGCHLBA2VLImJz42f7bJh8wQsTGCzI3j519/CASStoDONUBVz2I/VID0MpiX3SGSnbOD2xUalbE5g==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/inflight": {
@@ -9736,6 +11072,22 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/into-stream": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-7.0.0.tgz",
+			"integrity": "sha512-2dYz766i9HprMBasCMvHMuazJ7u4WzhJwo5kb3iPSiW/iRYV6uPari3zHoqZlnuaR7V1bEiNMxikhp37rdBXbw==",
+			"dev": true,
+			"dependencies": {
+				"from2": "^2.3.0",
+				"p-is-promise": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-arguments": {
@@ -10159,6 +11511,18 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-text-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-text-path/-/is-text-path-2.0.0.tgz",
+			"integrity": "sha512-+oDTluR6WEjdXEJMnC2z6A4FRwFoYuvShVVEGsS7ewc0UTi2QtAKMDJuL4BDEVt+5T7MjFo12RP8ghOM75oKJw==",
+			"dev": true,
+			"dependencies": {
+				"text-extensions": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/is-typed-array": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.13.tgz",
@@ -10264,6 +11628,22 @@
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
 			"integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
 			"dev": true
+		},
+		"node_modules/issue-parser": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/issue-parser/-/issue-parser-6.0.0.tgz",
+			"integrity": "sha512-zKa/Dxq2lGsBIXQ7CUZWTHfvxPC2ej0KfO7fIPqLlHB9J2hJ7rGhZ5rilhuufylr4RXYPzJUeFjKxz305OsNlA==",
+			"dev": true,
+			"dependencies": {
+				"lodash.capitalize": "^4.2.1",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isplainobject": "^4.0.6",
+				"lodash.isstring": "^4.0.1",
+				"lodash.uniqby": "^4.7.0"
+			},
+			"engines": {
+				"node": ">=10.13"
+			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.2",
@@ -10401,6 +11781,15 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/java-properties": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
+			"integrity": "sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.6.0"
 			}
 		},
 		"node_modules/jest": {
@@ -11620,6 +13009,31 @@
 				"graceful-fs": "^4.1.6"
 			}
 		},
+		"node_modules/jsonparse": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+			"integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			]
+		},
+		"node_modules/JSONStream": {
+			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+			"integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+			"dev": true,
+			"dependencies": {
+				"jsonparse": "^1.2.0",
+				"through": ">=2.2.7 <3"
+			},
+			"bin": {
+				"JSONStream": "bin.js"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/jsprim": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-2.0.2.tgz",
@@ -12001,12 +13415,30 @@
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
 		},
+		"node_modules/lodash-es": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+			"integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+			"dev": true
+		},
+		"node_modules/lodash.capitalize": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+			"integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+			"dev": true
+		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
 			"integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
 			"dev": true,
 			"peer": true
+		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+			"dev": true
 		},
 		"node_modules/lodash.flattendeep": {
 			"version": "4.4.0",
@@ -12026,6 +13458,18 @@
 			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
 			"dev": true
 		},
+		"node_modules/lodash.isplainobject": {
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
+		},
+		"node_modules/lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+			"dev": true
+		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -12036,6 +13480,12 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+			"dev": true
+		},
+		"node_modules/lodash.uniqby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+			"integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
 			"dev": true
 		},
 		"node_modules/log-symbols": {
@@ -12236,6 +13686,102 @@
 			"integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
 			"dev": true
 		},
+		"node_modules/marked": {
+			"version": "9.1.6",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-9.1.6.tgz",
+			"integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
+			"dev": true,
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 16"
+			}
+		},
+		"node_modules/marked-terminal": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-6.2.0.tgz",
+			"integrity": "sha512-ubWhwcBFHnXsjYNsu+Wndpg0zhY4CahSpPlA70PlO0rR9r2sZpkyU+rkCsOWH+KMEkx847UpALON+HWgxowFtw==",
+			"dev": true,
+			"dependencies": {
+				"ansi-escapes": "^6.2.0",
+				"cardinal": "^2.1.1",
+				"chalk": "^5.3.0",
+				"cli-table3": "^0.6.3",
+				"node-emoji": "^2.1.3",
+				"supports-hyperlinks": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			},
+			"peerDependencies": {
+				"marked": ">=1 <12"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/ansi-escapes": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.0.tgz",
+			"integrity": "sha512-kzRaCqXnpzWs+3z5ABPQiVke+iq0KXkHo8xiWV4RPTi5Yli0l97BEQuhXV1s7+aSU/fu1kUuxgS4MsQ0fRuygw==",
+			"dev": true,
+			"dependencies": {
+				"type-fest": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/chalk": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+			"integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+			"dev": true,
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/supports-hyperlinks": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.0.0.tgz",
+			"integrity": "sha512-QBDPHyPQDRTy9ku4URNGY5Lah8PAaXs6tAAwp55sL5WCsSW7GIfdf6W5ixfziW+t7wh3GVvHyHHyQ1ESsoRvaA==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0",
+				"supports-color": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=14.18"
+			}
+		},
+		"node_modules/marked-terminal/node_modules/type-fest": {
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.13.1.tgz",
+			"integrity": "sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/meow": {
+			"version": "12.1.1",
+			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
+			"integrity": "sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/merge-stream": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12262,6 +13808,21 @@
 			},
 			"engines": {
 				"node": ">=8.6"
+			}
+		},
+		"node_modules/mime": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mime/-/mime-4.0.1.tgz",
+			"integrity": "sha512-5lZ5tyrIfliMXzFtkYyekWbtRXObT9OWa8IwQ5uxTBDHucNNwniRqo0yInflj+iYi5CBa6qxadGzGarDfuEOxA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa"
+			],
+			"bin": {
+				"mime": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/mime-db": {
@@ -12595,8 +14156,28 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true
+		},
+		"node_modules/nerf-dart": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz",
+			"integrity": "sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==",
+			"dev": true
+		},
+		"node_modules/node-emoji": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
+			"integrity": "sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==",
 			"dev": true,
-			"peer": true
+			"dependencies": {
+				"@sindresorhus/is": "^4.6.0",
+				"char-regex": "^1.0.2",
+				"emojilib": "^2.4.0",
+				"skin-tone": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/node-int64": {
 			"version": "0.4.0",
@@ -12624,6 +14205,54 @@
 			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
+		"node_modules/normalize-package-data": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.0.tgz",
+			"integrity": "sha512-UL7ELRVxYBHBgYEtZCXjxuD5vPxnmvMGq0jp/dGPKKrN7tfsBh2IY7TlJ15WWwdjRWD3RJbnsygUurTK3xkPkg==",
+			"dev": true,
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/normalize-package-data/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -12642,6 +14271,175 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/normalize-url": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+			"integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-10.4.0.tgz",
+			"integrity": "sha512-RS7Mx0OVfXlOcQLRePuDIYdFCVBPCNapWHplDK+mh7GDdP/Tvor4ocuybRRPSvfcRb2vjRJt1fHCqw3cr8qACQ==",
+			"bundleDependencies": [
+				"@isaacs/string-locale-compare",
+				"@npmcli/arborist",
+				"@npmcli/config",
+				"@npmcli/fs",
+				"@npmcli/map-workspaces",
+				"@npmcli/package-json",
+				"@npmcli/promise-spawn",
+				"@npmcli/run-script",
+				"@sigstore/tuf",
+				"abbrev",
+				"archy",
+				"cacache",
+				"chalk",
+				"ci-info",
+				"cli-columns",
+				"cli-table3",
+				"columnify",
+				"fastest-levenshtein",
+				"fs-minipass",
+				"glob",
+				"graceful-fs",
+				"hosted-git-info",
+				"ini",
+				"init-package-json",
+				"is-cidr",
+				"json-parse-even-better-errors",
+				"libnpmaccess",
+				"libnpmdiff",
+				"libnpmexec",
+				"libnpmfund",
+				"libnpmhook",
+				"libnpmorg",
+				"libnpmpack",
+				"libnpmpublish",
+				"libnpmsearch",
+				"libnpmteam",
+				"libnpmversion",
+				"make-fetch-happen",
+				"minimatch",
+				"minipass",
+				"minipass-pipeline",
+				"ms",
+				"node-gyp",
+				"nopt",
+				"normalize-package-data",
+				"npm-audit-report",
+				"npm-install-checks",
+				"npm-package-arg",
+				"npm-pick-manifest",
+				"npm-profile",
+				"npm-registry-fetch",
+				"npm-user-validate",
+				"npmlog",
+				"p-map",
+				"pacote",
+				"parse-conflict-json",
+				"proc-log",
+				"qrcode-terminal",
+				"read",
+				"semver",
+				"spdx-expression-parse",
+				"ssri",
+				"supports-color",
+				"tar",
+				"text-table",
+				"tiny-relative-date",
+				"treeverse",
+				"validate-npm-package-name",
+				"which",
+				"write-file-atomic"
+			],
+			"dev": true,
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/arborist": "^7.2.1",
+				"@npmcli/config": "^8.0.2",
+				"@npmcli/fs": "^3.1.0",
+				"@npmcli/map-workspaces": "^3.0.4",
+				"@npmcli/package-json": "^5.0.0",
+				"@npmcli/promise-spawn": "^7.0.1",
+				"@npmcli/run-script": "^7.0.4",
+				"@sigstore/tuf": "^2.3.0",
+				"abbrev": "^2.0.0",
+				"archy": "~1.0.0",
+				"cacache": "^18.0.2",
+				"chalk": "^5.3.0",
+				"ci-info": "^4.0.0",
+				"cli-columns": "^4.0.0",
+				"cli-table3": "^0.6.3",
+				"columnify": "^1.6.0",
+				"fastest-levenshtein": "^1.0.16",
+				"fs-minipass": "^3.0.3",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.11",
+				"hosted-git-info": "^7.0.1",
+				"ini": "^4.1.1",
+				"init-package-json": "^6.0.0",
+				"is-cidr": "^5.0.3",
+				"json-parse-even-better-errors": "^3.0.1",
+				"libnpmaccess": "^8.0.1",
+				"libnpmdiff": "^6.0.3",
+				"libnpmexec": "^7.0.4",
+				"libnpmfund": "^5.0.1",
+				"libnpmhook": "^10.0.0",
+				"libnpmorg": "^6.0.1",
+				"libnpmpack": "^6.0.3",
+				"libnpmpublish": "^9.0.2",
+				"libnpmsearch": "^7.0.0",
+				"libnpmteam": "^6.0.0",
+				"libnpmversion": "^5.0.1",
+				"make-fetch-happen": "^13.0.0",
+				"minimatch": "^9.0.3",
+				"minipass": "^7.0.4",
+				"minipass-pipeline": "^1.2.4",
+				"ms": "^2.1.2",
+				"node-gyp": "^10.0.1",
+				"nopt": "^7.2.0",
+				"normalize-package-data": "^6.0.0",
+				"npm-audit-report": "^5.0.0",
+				"npm-install-checks": "^6.3.0",
+				"npm-package-arg": "^11.0.1",
+				"npm-pick-manifest": "^9.0.0",
+				"npm-profile": "^9.0.0",
+				"npm-registry-fetch": "^16.1.0",
+				"npm-user-validate": "^2.0.0",
+				"npmlog": "^7.0.1",
+				"p-map": "^4.0.0",
+				"pacote": "^17.0.6",
+				"parse-conflict-json": "^3.0.1",
+				"proc-log": "^3.0.0",
+				"qrcode-terminal": "^0.12.0",
+				"read": "^2.1.0",
+				"semver": "^7.5.4",
+				"spdx-expression-parse": "^3.0.1",
+				"ssri": "^10.0.5",
+				"supports-color": "^9.4.0",
+				"tar": "^6.2.0",
+				"text-table": "~0.2.0",
+				"tiny-relative-date": "^1.3.0",
+				"treeverse": "^3.0.0",
+				"validate-npm-package-name": "^5.0.0",
+				"which": "^4.0.0",
+				"write-file-atomic": "^5.0.1"
+			},
+			"bin": {
+				"npm": "bin/npm-cli.js",
+				"npx": "bin/npx-cli.js"
+			},
+			"engines": {
+				"node": "^18.17.0 || >=20.5.0"
+			}
+		},
 		"node_modules/npm-run-path": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -12653,6 +14451,2595 @@
 			"engines": {
 				"node": ">=8"
 			}
+		},
+		"node_modules/npm/node_modules/@colors/colors": {
+			"version": "1.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=0.1.90"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^5.1.2",
+				"string-width-cjs": "npm:string-width@^4.2.0",
+				"strip-ansi": "^7.0.1",
+				"strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+				"wrap-ansi": "^8.1.0",
+				"wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
+			"version": "5.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/@npmcli/agent": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"http-proxy-agent": "^7.0.0",
+				"https-proxy-agent": "^7.0.1",
+				"lru-cache": "^10.0.1",
+				"socks-proxy-agent": "^8.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/arborist": {
+			"version": "7.3.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@isaacs/string-locale-compare": "^1.1.0",
+				"@npmcli/fs": "^3.1.0",
+				"@npmcli/installed-package-contents": "^2.0.2",
+				"@npmcli/map-workspaces": "^3.0.2",
+				"@npmcli/metavuln-calculator": "^7.0.0",
+				"@npmcli/name-from-folder": "^2.0.0",
+				"@npmcli/node-gyp": "^3.0.0",
+				"@npmcli/package-json": "^5.0.0",
+				"@npmcli/query": "^3.0.1",
+				"@npmcli/run-script": "^7.0.2",
+				"bin-links": "^4.0.1",
+				"cacache": "^18.0.0",
+				"common-ancestor-path": "^1.0.1",
+				"hosted-git-info": "^7.0.1",
+				"json-parse-even-better-errors": "^3.0.0",
+				"json-stringify-nice": "^1.1.4",
+				"minimatch": "^9.0.0",
+				"nopt": "^7.0.0",
+				"npm-install-checks": "^6.2.0",
+				"npm-package-arg": "^11.0.1",
+				"npm-pick-manifest": "^9.0.0",
+				"npm-registry-fetch": "^16.0.0",
+				"npmlog": "^7.0.1",
+				"pacote": "^17.0.4",
+				"parse-conflict-json": "^3.0.0",
+				"proc-log": "^3.0.0",
+				"promise-all-reject-late": "^1.0.0",
+				"promise-call-limit": "^3.0.1",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.7",
+				"ssri": "^10.0.5",
+				"treeverse": "^3.0.0",
+				"walk-up-path": "^3.0.1"
+			},
+			"bin": {
+				"arborist": "bin/index.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/config": {
+			"version": "8.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/map-workspaces": "^3.0.2",
+				"ci-info": "^4.0.0",
+				"ini": "^4.1.0",
+				"nopt": "^7.0.0",
+				"proc-log": "^3.0.0",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.5",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/disparity-colors": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ansi-styles": "^4.3.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/fs": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/git": {
+			"version": "5.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/promise-spawn": "^7.0.0",
+				"lru-cache": "^10.0.1",
+				"npm-pick-manifest": "^9.0.0",
+				"proc-log": "^3.0.0",
+				"promise-inflight": "^1.0.1",
+				"promise-retry": "^2.0.1",
+				"semver": "^7.3.5",
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-bundled": "^3.0.0",
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"bin": {
+				"installed-package-contents": "lib/index.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
+			"version": "3.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/name-from-folder": "^2.0.0",
+				"glob": "^10.2.2",
+				"minimatch": "^9.0.0",
+				"read-package-json-fast": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cacache": "^18.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"pacote": "^17.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/node-gyp": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/package-json": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"glob": "^10.2.2",
+				"hosted-git-info": "^7.0.0",
+				"json-parse-even-better-errors": "^3.0.0",
+				"normalize-package-data": "^6.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/query": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"postcss-selector-parser": "^6.0.10"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@npmcli/run-script": {
+			"version": "7.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/node-gyp": "^3.0.0",
+				"@npmcli/package-json": "^5.0.0",
+				"@npmcli/promise-spawn": "^7.0.0",
+				"node-gyp": "^10.0.0",
+				"which": "^4.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@pkgjs/parseargs": {
+			"version": "0.11.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/bundle": {
+			"version": "2.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.2.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/core": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
+			"version": "0.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/sign": {
+			"version": "2.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.1.1",
+				"@sigstore/core": "^0.2.0",
+				"@sigstore/protobuf-specs": "^0.2.1",
+				"make-fetch-happen": "^13.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/tuf": {
+			"version": "2.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/protobuf-specs": "^0.2.1",
+				"tuf-js": "^2.2.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@sigstore/verify": {
+			"version": "0.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.1.1",
+				"@sigstore/core": "^0.2.0",
+				"@sigstore/protobuf-specs": "^0.2.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/canonical-json": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/@tufjs/models": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/canonical-json": "2.0.0",
+				"minimatch": "^9.0.3"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/abbrev": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/agent-base": {
+			"version": "7.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/aggregate-error": {
+			"version": "3.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clean-stack": "^2.0.0",
+				"indent-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-regex": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ansi-styles": {
+			"version": "6.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/aproba": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/archy": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/are-we-there-yet": {
+			"version": "4.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/bin-links": {
+			"version": "4.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cmd-shim": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"read-cmd-shim": "^4.0.0",
+				"write-file-atomic": "^5.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/binary-extensions": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/brace-expansion": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^1.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/builtins": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"semver": "^7.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/cacache": {
+			"version": "18.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/fs": "^3.1.0",
+				"fs-minipass": "^3.0.0",
+				"glob": "^10.2.2",
+				"lru-cache": "^10.0.1",
+				"minipass": "^7.0.3",
+				"minipass-collect": "^2.0.1",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"p-map": "^4.0.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11",
+				"unique-filename": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/chalk": {
+			"version": "5.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/chownr": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/ci-info": {
+			"version": "4.0.0",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/cidr-regex": {
+			"version": "4.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"ip-regex": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/clean-stack": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/cli-columns": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/npm/node_modules/cli-table3": {
+			"version": "0.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"string-width": "^4.2.0"
+			},
+			"engines": {
+				"node": "10.* || >= 12.*"
+			},
+			"optionalDependencies": {
+				"@colors/colors": "1.5.0"
+			}
+		},
+		"node_modules/npm/node_modules/clone": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
+			}
+		},
+		"node_modules/npm/node_modules/cmd-shim": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-convert": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/color-name": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/color-support": {
+			"version": "1.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"bin": {
+				"color-support": "bin.js"
+			}
+		},
+		"node_modules/npm/node_modules/columnify": {
+			"version": "1.6.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"strip-ansi": "^6.0.1",
+				"wcwidth": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/common-ancestor-path": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/console-control-strings": {
+			"version": "1.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/cross-spawn": {
+			"version": "7.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
+			"version": "2.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/cssesc": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"cssesc": "bin/cssesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/debug": {
+			"version": "4.3.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.1.2"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/npm/node_modules/debug/node_modules/ms": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/defaults": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"clone": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/diff": {
+			"version": "5.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/npm/node_modules/eastasianwidth": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/emoji-regex": {
+			"version": "8.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/encoding": {
+			"version": "0.1.13",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"iconv-lite": "^0.6.2"
+			}
+		},
+		"node_modules/npm/node_modules/env-paths": {
+			"version": "2.2.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/npm/node_modules/err-code": {
+			"version": "2.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/exponential-backoff": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/npm/node_modules/fastest-levenshtein": {
+			"version": "1.0.16",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.9.1"
+			}
+		},
+		"node_modules/npm/node_modules/foreground-child": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"cross-spawn": "^7.0.0",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/fs-minipass": {
+			"version": "3.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/function-bind": {
+			"version": "1.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/npm/node_modules/gauge": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^1.0.3 || ^2.0.0",
+				"color-support": "^1.1.3",
+				"console-control-strings": "^1.1.0",
+				"has-unicode": "^2.0.1",
+				"signal-exit": "^4.0.1",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
+				"wide-align": "^1.1.5"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/glob": {
+			"version": "10.3.10",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^2.3.5",
+				"minimatch": "^9.0.1",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+				"path-scurry": "^1.10.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/has-unicode": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/hasown": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/npm/node_modules/hosted-git-info": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^10.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/http-cache-semantics": {
+			"version": "4.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/npm/node_modules/http-proxy-agent": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/https-proxy-agent": {
+			"version": "7.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/npm/node_modules/ignore-walk": {
+			"version": "6.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minimatch": "^9.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/imurmurhash": {
+			"version": "0.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.19"
+			}
+		},
+		"node_modules/npm/node_modules/indent-string": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/ini": {
+			"version": "4.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/init-package-json": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^11.0.0",
+				"promzard": "^1.0.0",
+				"read": "^2.0.0",
+				"read-package-json": "^7.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/ip": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/ip-regex": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/is-cidr": {
+			"version": "5.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"cidr-regex": "4.0.3"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/npm/node_modules/is-core-module": {
+			"version": "2.13.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"hasown": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/npm/node_modules/is-fullwidth-code-point": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/is-lambda": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/isexe": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/jackspeak": {
+			"version": "2.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"@isaacs/cliui": "^8.0.2"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			},
+			"optionalDependencies": {
+				"@pkgjs/parseargs": "^0.11.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-parse-even-better-errors": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/json-stringify-nice": {
+			"version": "1.1.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/jsonparse": {
+			"version": "1.3.1",
+			"dev": true,
+			"engines": [
+				"node >= 0.2.0"
+			],
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/just-diff-apply": {
+			"version": "5.5.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/libnpmaccess": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-package-arg": "^11.0.1",
+				"npm-registry-fetch": "^16.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmdiff": {
+			"version": "6.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.2.1",
+				"@npmcli/disparity-colors": "^3.0.0",
+				"@npmcli/installed-package-contents": "^2.0.2",
+				"binary-extensions": "^2.2.0",
+				"diff": "^5.1.0",
+				"minimatch": "^9.0.0",
+				"npm-package-arg": "^11.0.1",
+				"pacote": "^17.0.4",
+				"tar": "^6.2.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmexec": {
+			"version": "7.0.7",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.2.1",
+				"@npmcli/run-script": "^7.0.2",
+				"ci-info": "^4.0.0",
+				"npm-package-arg": "^11.0.1",
+				"npmlog": "^7.0.1",
+				"pacote": "^17.0.4",
+				"proc-log": "^3.0.0",
+				"read": "^2.0.0",
+				"read-package-json-fast": "^3.0.2",
+				"semver": "^7.3.7",
+				"walk-up-path": "^3.0.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmfund": {
+			"version": "5.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.2.1"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmhook": {
+			"version": "10.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^16.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmorg": {
+			"version": "6.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^16.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpack": {
+			"version": "6.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/arborist": "^7.2.1",
+				"@npmcli/run-script": "^7.0.2",
+				"npm-package-arg": "^11.0.1",
+				"pacote": "^17.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmpublish": {
+			"version": "9.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ci-info": "^4.0.0",
+				"normalize-package-data": "^6.0.0",
+				"npm-package-arg": "^11.0.1",
+				"npm-registry-fetch": "^16.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.3.7",
+				"sigstore": "^2.2.0",
+				"ssri": "^10.0.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmsearch": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^16.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmteam": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"aproba": "^2.0.0",
+				"npm-registry-fetch": "^16.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/libnpmversion": {
+			"version": "5.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.3",
+				"@npmcli/run-script": "^7.0.2",
+				"json-parse-even-better-errors": "^3.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.3.7"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/lru-cache": {
+			"version": "10.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "14 || >=16.14"
+			}
+		},
+		"node_modules/npm/node_modules/make-fetch-happen": {
+			"version": "13.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/agent": "^2.0.0",
+				"cacache": "^18.0.0",
+				"http-cache-semantics": "^4.1.1",
+				"is-lambda": "^1.0.1",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-flush": "^1.0.5",
+				"minipass-pipeline": "^1.2.4",
+				"negotiator": "^0.6.3",
+				"promise-retry": "^2.0.1",
+				"ssri": "^10.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/minimatch": {
+			"version": "9.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/minipass": {
+			"version": "7.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-collect": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-fetch": {
+			"version": "3.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^7.0.3",
+				"minipass-sized": "^1.0.3",
+				"minizlib": "^2.1.2"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			},
+			"optionalDependencies": {
+				"encoding": "^0.1.13"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush": {
+			"version": "1.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-json-stream": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"jsonparse": "^1.3.1",
+				"minipass": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline": {
+			"version": "1.2.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized": {
+			"version": "1.0.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/minizlib": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"minipass": "^3.0.0",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/minizlib/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/mkdirp": {
+			"version": "1.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/ms": {
+			"version": "2.1.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/mute-stream": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/negotiator": {
+			"version": "0.6.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/npm/node_modules/node-gyp": {
+			"version": "10.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"env-paths": "^2.2.0",
+				"exponential-backoff": "^3.1.1",
+				"glob": "^10.3.10",
+				"graceful-fs": "^4.2.6",
+				"make-fetch-happen": "^13.0.0",
+				"nopt": "^7.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.3.5",
+				"tar": "^6.1.2",
+				"which": "^4.0.0"
+			},
+			"bin": {
+				"node-gyp": "bin/node-gyp.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/nopt": {
+			"version": "7.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"abbrev": "^2.0.0"
+			},
+			"bin": {
+				"nopt": "bin/nopt.js"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/normalize-package-data": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"is-core-module": "^2.8.1",
+				"semver": "^7.3.5",
+				"validate-npm-package-license": "^3.0.4"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-audit-report": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-bundled": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-install-checks": {
+			"version": "6.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"semver": "^7.1.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-normalize-package-bin": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-package-arg": {
+			"version": "11.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"hosted-git-info": "^7.0.0",
+				"proc-log": "^3.0.0",
+				"semver": "^7.3.5",
+				"validate-npm-package-name": "^5.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-packlist": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"ignore-walk": "^6.0.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-pick-manifest": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-install-checks": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0",
+				"npm-package-arg": "^11.0.0",
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-profile": {
+			"version": "9.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"npm-registry-fetch": "^16.0.0",
+				"proc-log": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-registry-fetch": {
+			"version": "16.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"make-fetch-happen": "^13.0.0",
+				"minipass": "^7.0.2",
+				"minipass-fetch": "^3.0.0",
+				"minipass-json-stream": "^1.0.1",
+				"minizlib": "^2.1.2",
+				"npm-package-arg": "^11.0.0",
+				"proc-log": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npm-user-validate": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/npmlog": {
+			"version": "7.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"are-we-there-yet": "^4.0.0",
+				"console-control-strings": "^1.1.0",
+				"gauge": "^5.0.0",
+				"set-blocking": "^2.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/p-map": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"aggregate-error": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/pacote": {
+			"version": "17.0.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"@npmcli/git": "^5.0.0",
+				"@npmcli/installed-package-contents": "^2.0.1",
+				"@npmcli/promise-spawn": "^7.0.0",
+				"@npmcli/run-script": "^7.0.0",
+				"cacache": "^18.0.0",
+				"fs-minipass": "^3.0.0",
+				"minipass": "^7.0.2",
+				"npm-package-arg": "^11.0.0",
+				"npm-packlist": "^8.0.0",
+				"npm-pick-manifest": "^9.0.0",
+				"npm-registry-fetch": "^16.0.0",
+				"proc-log": "^3.0.0",
+				"promise-retry": "^2.0.1",
+				"read-package-json": "^7.0.0",
+				"read-package-json-fast": "^3.0.0",
+				"sigstore": "^2.2.0",
+				"ssri": "^10.0.0",
+				"tar": "^6.1.11"
+			},
+			"bin": {
+				"pacote": "lib/bin.js"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/parse-conflict-json": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^3.0.0",
+				"just-diff": "^6.0.0",
+				"just-diff-apply": "^5.2.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/path-key": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/path-scurry": {
+			"version": "1.10.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^9.1.1 || ^10.0.0",
+				"minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/postcss-selector-parser": {
+			"version": "6.0.15",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssesc": "^3.0.0",
+				"util-deprecate": "^1.0.2"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/npm/node_modules/proc-log": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/promise-all-reject-late": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-call-limit": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/promise-inflight": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/promise-retry": {
+			"version": "2.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"err-code": "^2.0.2",
+				"retry": "^0.12.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/promzard": {
+			"version": "1.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"read": "^2.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/qrcode-terminal": {
+			"version": "0.12.0",
+			"dev": true,
+			"inBundle": true,
+			"bin": {
+				"qrcode-terminal": "bin/qrcode-terminal.js"
+			}
+		},
+		"node_modules/npm/node_modules/read": {
+			"version": "2.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"mute-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-cmd-shim": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json": {
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.2.2",
+				"json-parse-even-better-errors": "^3.0.0",
+				"normalize-package-data": "^6.0.0",
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/read-package-json-fast": {
+			"version": "3.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"json-parse-even-better-errors": "^3.0.0",
+				"npm-normalize-package-bin": "^3.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/retry": {
+			"version": "0.12.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/npm/node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"optional": true
+		},
+		"node_modules/npm/node_modules/semver": {
+			"version": "7.5.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/set-blocking": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/npm/node_modules/sigstore": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@sigstore/bundle": "^2.1.1",
+				"@sigstore/core": "^0.2.0",
+				"@sigstore/protobuf-specs": "^0.2.1",
+				"@sigstore/sign": "^2.2.1",
+				"@sigstore/tuf": "^2.3.0",
+				"@sigstore/verify": "^0.1.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/smart-buffer": {
+			"version": "4.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 6.0.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks": {
+			"version": "2.7.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ip": "^2.0.0",
+				"smart-buffer": "^4.2.0"
+			},
+			"engines": {
+				"node": ">= 10.13.0",
+				"npm": ">= 3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/socks-proxy-agent": {
+			"version": "8.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.0.2",
+				"debug": "^4.3.4",
+				"socks": "^2.7.1"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-exceptions": {
+			"version": "2.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC-BY-3.0"
+		},
+		"node_modules/npm/node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/spdx-license-ids": {
+			"version": "3.0.16",
+			"dev": true,
+			"inBundle": true,
+			"license": "CC0-1.0"
+		},
+		"node_modules/npm/node_modules/ssri": {
+			"version": "10.0.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^7.0.3"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/string-width": {
+			"version": "4.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/string-width-cjs": {
+			"name": "string-width",
+			"version": "4.2.3",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"emoji-regex": "^8.0.0",
+				"is-fullwidth-code-point": "^3.0.0",
+				"strip-ansi": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/strip-ansi-cjs": {
+			"name": "strip-ansi",
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/supports-color": {
+			"version": "9.4.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/tar": {
+			"version": "6.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"chownr": "^2.0.0",
+				"fs-minipass": "^2.0.0",
+				"minipass": "^5.0.0",
+				"minizlib": "^2.1.1",
+				"mkdirp": "^1.0.3",
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
+			"version": "2.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"minipass": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
+			"version": "3.3.6",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/tar/node_modules/minipass": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/npm/node_modules/text-table": {
+			"version": "0.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/tiny-relative-date": {
+			"version": "1.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/treeverse": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/tuf-js": {
+			"version": "2.2.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tufjs/models": "2.0.0",
+				"debug": "^4.3.4",
+				"make-fetch-happen": "^13.0.0"
+			},
+			"engines": {
+				"node": "^16.14.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-filename": {
+			"version": "3.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"unique-slug": "^4.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/unique-slug": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"dev": true,
+			"inBundle": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/validate-npm-package-name": {
+			"version": "5.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"builtins": "^5.0.0"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/walk-up-path": {
+			"version": "3.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
+		},
+		"node_modules/npm/node_modules/wcwidth": {
+			"version": "1.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"defaults": "^1.0.3"
+			}
+		},
+		"node_modules/npm/node_modules/which": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^3.1.1"
+			},
+			"bin": {
+				"node-which": "bin/which.js"
+			},
+			"engines": {
+				"node": "^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/which/node_modules/isexe": {
+			"version": "3.1.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/npm/node_modules/wide-align": {
+			"version": "1.1.5",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^1.0.2 || 2 || 3 || 4"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi": {
+			"version": "8.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^6.1.0",
+				"string-width": "^5.0.1",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs": {
+			"name": "wrap-ansi",
+			"version": "7.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.0.0",
+				"string-width": "^4.1.0",
+				"strip-ansi": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
+			"version": "9.2.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT"
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
+			"version": "5.1.2",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"eastasianwidth": "^0.2.0",
+				"emoji-regex": "^9.2.2",
+				"strip-ansi": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/npm/node_modules/write-file-atomic": {
+			"version": "5.0.1",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC",
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^4.0.1"
+			},
+			"engines": {
+				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+			}
+		},
+		"node_modules/npm/node_modules/yallist": {
+			"version": "4.0.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "ISC"
 		},
 		"node_modules/nwsapi": {
 			"version": "2.2.7",
@@ -13037,6 +17424,54 @@
 			"integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
 			"dev": true
 		},
+		"node_modules/p-each-series": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+			"integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-filter": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-filter/-/p-filter-4.1.0.tgz",
+			"integrity": "sha512-37/tPdZ3oJwHaS3gNJdenCDB3Tz26i9sjhnguBtvN0vYlRIiDNnvTWkuh+0hETV9rLPdJ3rlL3yVOYPIAnM8rw==",
+			"dev": true,
+			"dependencies": {
+				"p-map": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-filter/node_modules/p-map": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.1.tgz",
+			"integrity": "sha512-2wnaR0XL/FDOj+TgpDuRb2KTjLnu3Fma6b1ZUwGY7LcqenMcvP/YFpjpbPKY6WVGsbuJZRuoUz8iPrt8ORnAFw==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-is-promise": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+			"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -13092,6 +17527,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-reduce": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-2.1.0.tgz",
+			"integrity": "sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/p-try": {
@@ -13290,6 +17734,132 @@
 			"peer": true,
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/pkg-conf": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-2.1.0.tgz",
+			"integrity": "sha512-C+VUP+8jis7EsQZIhDYmS5qlNtjv2yP4SNtjXK9AP1ZcTRlnSfuumaTnRfYZnYgUUYVIKqL0fRvmUGDV2fmp6g==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^2.0.0",
+				"load-json-file": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/find-up": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+			"integrity": "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/load-json-file": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+			"integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
+			"dev": true,
+			"dependencies": {
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^4.0.0",
+				"pify": "^3.0.0",
+				"strip-bom": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/locate-path": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+			"integrity": "sha512-NCI2kiDkyR7VeEKm27Kda/iQHyKJe1Bu0FlTbYp3CqJu+9IFe9bLyAjMxf5ZDDbEg+iMPzB5zYyUTSm8wVTKmA==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-limit": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
+			"dependencies": {
+				"p-try": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-locate": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+			"integrity": "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/parse-json": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+			"integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+			"dev": true,
+			"dependencies": {
+				"error-ex": "^1.3.1",
+				"json-parse-better-errors": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/path-exists": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+			"integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/pify": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+			"integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/pkg-conf/node_modules/strip-bom": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+			"integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/pkg-dir": {
@@ -13548,6 +18118,12 @@
 				"node": ">= 0.6.0"
 			}
 		},
+		"node_modules/process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
+		},
 		"node_modules/process-on-spawn": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -13590,6 +18166,12 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
+		},
+		"node_modules/proto-list": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+			"integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
 			"dev": true
 		},
 		"node_modules/proxy-from-env": {
@@ -13707,6 +18289,36 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
+		"node_modules/rc": {
+			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
+			"dependencies": {
+				"deep-extend": "^0.6.0",
+				"ini": "~1.3.0",
+				"minimist": "^1.2.0",
+				"strip-json-comments": "~2.0.1"
+			},
+			"bin": {
+				"rc": "cli.js"
+			}
+		},
+		"node_modules/rc/node_modules/ini": {
+			"version": "1.3.8",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true
+		},
+		"node_modules/rc/node_modules/strip-json-comments": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/react": {
 			"version": "18.2.0",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
@@ -13778,6 +18390,111 @@
 				"react": ">=16.8",
 				"react-dom": ">=16.8"
 			}
+		},
+		"node_modules/read-pkg": {
+			"version": "9.0.1",
+			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+			"integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+			"dev": true,
+			"dependencies": {
+				"@types/normalize-package-data": "^2.4.3",
+				"normalize-package-data": "^6.0.0",
+				"parse-json": "^8.0.0",
+				"type-fest": "^4.6.0",
+				"unicorn-magic": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg-up": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-11.0.0.tgz",
+			"integrity": "sha512-LOVbvF1Q0SZdjClSefZ0Nz5z8u+tIE7mV5NibzmE9VYmDe9CaBbAVtz1veOSZbofrdsilxuDAYnFenukZVp8/Q==",
+			"deprecated": "Renamed to read-package-up",
+			"dev": true,
+			"dependencies": {
+				"find-up-simple": "^1.0.0",
+				"read-pkg": "^9.0.0",
+				"type-fest": "^4.6.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg-up/node_modules/type-fest": {
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.3.tgz",
+			"integrity": "sha512-JLXyjizi072smKGGcZiAJDCNweT8J+AuRxmPZ1aG7TERg4ijx9REl8CNhbr36RV4qXqL1gO1FF9HL8OkVmmrsA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/parse-json": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.1.0.tgz",
+			"integrity": "sha512-rum1bPifK5SSar35Z6EKZuYPJx85pkNaFrxBK3mwdfSJ1/WKbYrjoW/zTPSjRRamfmVX1ACBIdFAO0VRErW/EA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.22.13",
+				"index-to-position": "^0.1.2",
+				"type-fest": "^4.7.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/read-pkg/node_modules/type-fest": {
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.10.3.tgz",
+			"integrity": "sha512-JLXyjizi072smKGGcZiAJDCNweT8J+AuRxmPZ1aG7TERg4ijx9REl8CNhbr36RV4qXqL1gO1FF9HL8OkVmmrsA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "2.3.8",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
+			"dependencies": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			}
+		},
+		"node_modules/readable-stream/node_modules/isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
+		},
+		"node_modules/readable-stream/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/readdirp": {
 			"version": "3.6.0",
@@ -13904,6 +18621,18 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/registry-auth-token": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+			"integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+			"dev": true,
+			"dependencies": {
+				"@pnpm/npm-conf": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=14"
 			}
 		},
 		"node_modules/regjsparser": {
@@ -14284,6 +19013,357 @@
 			"dev": true,
 			"peer": true
 		},
+		"node_modules/semantic-release": {
+			"version": "22.0.12",
+			"resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-22.0.12.tgz",
+			"integrity": "sha512-0mhiCR/4sZb00RVFJIUlMuiBkW3NMpVIW2Gse7noqEMoFGkvfPPAImEQbkBV8xga4KOPP4FdTRYuLLy32R1fPw==",
+			"dev": true,
+			"dependencies": {
+				"@semantic-release/commit-analyzer": "^11.0.0",
+				"@semantic-release/error": "^4.0.0",
+				"@semantic-release/github": "^9.0.0",
+				"@semantic-release/npm": "^11.0.0",
+				"@semantic-release/release-notes-generator": "^12.0.0",
+				"aggregate-error": "^5.0.0",
+				"cosmiconfig": "^8.0.0",
+				"debug": "^4.0.0",
+				"env-ci": "^10.0.0",
+				"execa": "^8.0.0",
+				"figures": "^6.0.0",
+				"find-versions": "^5.1.0",
+				"get-stream": "^6.0.0",
+				"git-log-parser": "^1.2.0",
+				"hook-std": "^3.0.0",
+				"hosted-git-info": "^7.0.0",
+				"import-from-esm": "^1.3.1",
+				"lodash-es": "^4.17.21",
+				"marked": "^9.0.0",
+				"marked-terminal": "^6.0.0",
+				"micromatch": "^4.0.2",
+				"p-each-series": "^3.0.0",
+				"p-reduce": "^3.0.0",
+				"read-pkg-up": "^11.0.0",
+				"resolve-from": "^5.0.0",
+				"semver": "^7.3.2",
+				"semver-diff": "^4.0.0",
+				"signale": "^1.2.1",
+				"yargs": "^17.5.1"
+			},
+			"bin": {
+				"semantic-release": "bin/semantic-release.js"
+			},
+			"engines": {
+				"node": "^18.17 || >=20.6.1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/@semantic-release/error": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+			"integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/semantic-release/node_modules/aggregate-error": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
+			"integrity": "sha512-gOsf2YwSlleG6IjRYG2A7k0HmBMEo6qVNk9Bp/EaLgAJT5ngH6PXbqa4ItvnEwCm/velL5jAnQgsHsWnjhGmvw==",
+			"dev": true,
+			"dependencies": {
+				"clean-stack": "^5.2.0",
+				"indent-string": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/clean-stack": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-5.2.0.tgz",
+			"integrity": "sha512-TyUIUJgdFnCISzG5zu3291TAsE77ddchd0bepon1VVQrKLGKFED4iXFEDQ24mIPdPBbyE16PK3F8MYE1CmcBEQ==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "5.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/semantic-release/node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+			"integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+			"dev": true,
+			"dependencies": {
+				"cross-spawn": "^7.0.3",
+				"get-stream": "^8.0.1",
+				"human-signals": "^5.0.0",
+				"is-stream": "^3.0.0",
+				"merge-stream": "^2.0.0",
+				"npm-run-path": "^5.1.0",
+				"onetime": "^6.0.0",
+				"signal-exit": "^4.1.0",
+				"strip-final-newline": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=16.17"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/execa?sponsor=1"
+			}
+		},
+		"node_modules/semantic-release/node_modules/execa/node_modules/get-stream": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+			"integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+			"dev": true,
+			"engines": {
+				"node": ">=16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/figures": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-6.0.1.tgz",
+			"integrity": "sha512-0oY/olScYD4IhQ8u//gCPA4F3mlTn2dacYmiDm/mbDQvpmLjV4uH+zhsQ5IyXRyvqkvtUkXkNdGvg5OFJTCsuQ==",
+			"dev": true,
+			"dependencies": {
+				"is-unicode-supported": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/get-stream": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+			"integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/human-signals": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+			"integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=16.17.0"
+			}
+		},
+		"node_modules/semantic-release/node_modules/indent-string": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+			"integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/is-unicode-supported": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.0.0.tgz",
+			"integrity": "sha512-FRdAyx5lusK1iHG0TWpVtk9+1i+GjrzRffhDg4ovQ7mcidMQ6mj+MhKPmvh7Xwyv5gIS06ns49CA7Sqg7lC22Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semantic-release/node_modules/mimic-fn": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+			"integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/npm-run-path": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+			"integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+			"dev": true,
+			"dependencies": {
+				"path-key": "^4.0.0"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/onetime": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+			"integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+			"dev": true,
+			"dependencies": {
+				"mimic-fn": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/p-reduce": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+			"integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/path-key": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+			"integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semantic-release/node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/semantic-release/node_modules/strip-final-newline": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+			"integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semantic-release/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
 		"node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -14298,6 +19378,66 @@
 			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
 			"integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
 			"dev": true
+		},
+		"node_modules/semver-diff": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+			"integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+			"dev": true,
+			"dependencies": {
+				"semver": "^7.3.5"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/semver-diff/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver-diff/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/semver-diff/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
+		},
+		"node_modules/semver-regex": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+			"integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.0",
@@ -14398,6 +19538,103 @@
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
 			"dev": true
 		},
+		"node_modules/signale": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/signale/-/signale-1.4.0.tgz",
+			"integrity": "sha512-iuh+gPf28RkltuJC7W5MRi6XAjTDCAPC/prJUpQoG4vIP3MJZ+GTydVnodXA7pwvTKb2cA0m9OFZW/cdWy/I/w==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.3.2",
+				"figures": "^2.0.0",
+				"pkg-conf": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/signale/node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/signale/node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+			"dev": true
+		},
+		"node_modules/signale/node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/signale/node_modules/figures": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+			"integrity": "sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==",
+			"dev": true,
+			"dependencies": {
+				"escape-string-regexp": "^1.0.5"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/signale/node_modules/supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/sirv": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
@@ -14484,6 +19721,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/skin-tone": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+			"integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+			"dev": true,
+			"dependencies": {
+				"unicode-emoji-modifier-base": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -14537,6 +19786,12 @@
 				"source-map": "^0.6.0"
 			}
 		},
+		"node_modules/spawn-error-forwarder": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz",
+			"integrity": "sha512-gRjMgK5uFjbCvdibeGJuy3I5OYz6VLoVdsOJdA6wV0WlfQVLFueoqMxwwYD9RODdgb6oUIvlRlsyFSiQkMKu0g==",
+			"dev": true
+		},
 		"node_modules/spawn-wrap": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -14569,6 +19824,38 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/spdx-correct": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dev": true,
+			"dependencies": {
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-exceptions": {
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+			"integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+			"dev": true
+		},
+		"node_modules/spdx-expression-parse": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
+			"dependencies": {
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
+			}
+		},
+		"node_modules/spdx-license-ids": {
+			"version": "3.0.17",
+			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+			"integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
+			"dev": true
+		},
 		"node_modules/split": {
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
@@ -14579,6 +19866,15 @@
 			},
 			"engines": {
 				"node": "*"
+			}
+		},
+		"node_modules/split2": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+			"integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+			"dev": true,
+			"engines": {
+				"node": ">= 10.x"
 			}
 		},
 		"node_modules/sprintf-js": {
@@ -14749,6 +20045,31 @@
 			"dependencies": {
 				"duplexer": "~0.1.1"
 			}
+		},
+		"node_modules/stream-combiner2": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+			"integrity": "sha512-3PnJbYgS56AeWgtKF5jtJRT6uFJe56Z0Hc5Ngg/6sI6rIt8iiMBTa9cvdyFfpMQjaVHr8dusbNeFGIIonxOvKw==",
+			"dev": true,
+			"dependencies": {
+				"duplexer2": "~0.1.0",
+				"readable-stream": "^2.0.2"
+			}
+		},
+		"node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
+		"node_modules/string_decoder/node_modules/safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/string-argv": {
 			"version": "0.3.1",
@@ -14999,6 +20320,57 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/temp-dir": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
+			"integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
+			"dev": true,
+			"engines": {
+				"node": ">=14.16"
+			}
+		},
+		"node_modules/tempy": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/tempy/-/tempy-3.1.0.tgz",
+			"integrity": "sha512-7jDLIdD2Zp0bDe5r3D2qtkd1QOCacylBuL7oa4udvN6v2pqr4+LcCr67C8DR1zkpaZ8XosF5m1yQSabKAW6f2g==",
+			"dev": true,
+			"dependencies": {
+				"is-stream": "^3.0.0",
+				"temp-dir": "^3.0.0",
+				"type-fest": "^2.12.2",
+				"unique-string": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/is-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+			"integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/tempy/node_modules/type-fest": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+			"integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/terser": {
 			"version": "5.27.2",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.27.2.tgz",
@@ -15145,6 +20517,18 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/text-extensions": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-2.4.0.tgz",
+			"integrity": "sha512-te/NtwBwfiNRLf9Ijqx3T0nlqZiQ2XrrtBvu+cLL8ZRrGkO0NHTug8MYFKyoSrv/sHTaSKfilUkizV6XhxMJ3g==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -15165,6 +20549,16 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
 			"dev": true
+		},
+		"node_modules/through2": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+			"integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+			"dev": true,
+			"dependencies": {
+				"readable-stream": "~2.3.6",
+				"xtend": "~4.0.1"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.6.0",
@@ -15276,6 +20670,18 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/traverse": {
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.8.tgz",
+			"integrity": "sha512-aXJDbk6SnumuaZSANd21XAo15ucCDE38H4fkqiGsc3MhCK+wOlZvLP9cB/TvpHT0mOyWgC4Z8EwRlzqYSUzdsA==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/ts-api-utils": {
@@ -15541,6 +20947,19 @@
 			"integrity": "sha512-Hhy+BhRBleFjpJ2vchUNN40qgkh0366FWJGqVLYBHev0vpHTrXSA0ryT+74UiW6KWsldNurQMKGqCm1M2zBciQ==",
 			"dev": true
 		},
+		"node_modules/uglify-js": {
+			"version": "3.17.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"dev": true,
+			"optional": true,
+			"bin": {
+				"uglifyjs": "bin/uglifyjs"
+			},
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -15568,6 +20987,15 @@
 			"integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
 			"dev": true,
 			"peer": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unicode-emoji-modifier-base": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+			"integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -15617,6 +21045,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/unique-string": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
+			"integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
+			"dev": true,
+			"dependencies": {
+				"crypto-random-string": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/universal-user-agent": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+			"integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+			"dev": true
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
@@ -15675,6 +21124,15 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/url-join": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/url-join/-/url-join-5.0.0.tgz",
+			"integrity": "sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
 		"node_modules/url-parse": {
 			"version": "1.5.10",
 			"resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -15684,6 +21142,12 @@
 				"querystringify": "^2.1.1",
 				"requires-port": "^1.0.0"
 			}
+		},
+		"node_modules/util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
@@ -15714,6 +21178,16 @@
 			},
 			"engines": {
 				"node": ">=10.12.0"
+			}
+		},
+		"node_modules/validate-npm-package-license": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
+			"dependencies": {
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"node_modules/validator": {
@@ -16600,12 +22074,20 @@
 			"optional": true,
 			"peer": true
 		},
+		"node_modules/xtend": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.4"
+			}
+		},
 		"node_modules/y18n": {
 			"version": "5.0.8",
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
 			"integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=10"
 			}
@@ -16630,8 +22112,6 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
 			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"cliui": "^8.0.1",
 				"escalade": "^3.1.1",
@@ -16702,8 +22182,6 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
 			"integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
 			"dev": true,
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
 		"docs:start": "cd ./documentation && npm run start",
 		"docs:start-ci": "cd ./documentation && npm run start",
 		"docs:build": "cd ./documentation && npm run build",
-		"docs:deploy": "cd ./documentation && GIT_USER=feedzai && npm run deploy",
 		"reinstall": "rm -rf node_modules && npm install",
 		"coverage:clean": "merge-coverage clear && merge-coverage clear --folder coverage",
 		"coverage:merge": "merge-coverage combine-coverage --tools cypress,vitest",
@@ -48,7 +47,8 @@
 		"test": "npm run test:unit-ci && npm run test:component-run && npm run test:e2e",
 		"posttest": "npm run coverage:merge && npm run coverage:combine-reports",
 		"test:ci": "npm run test:unit-ci && npm run test:component-run && npm run test:e2e",
-		"check-updates": "npx npm-check-updates --format group --interactive"
+		"check-updates": "npx npm-check-updates --format group --interactive",
+		"semantic-release": "semantic-release"
 	},
 	"peerDependencies": {
 		"react": ">=16.14.0",
@@ -61,6 +61,12 @@
 	"devDependencies": {
 		"@cypress/code-coverage": "3.12.24",
 		"@jtmdias/merge-coverage": "^1.1.0",
+		"@semantic-release/changelog": "^6.0.3",
+		"@semantic-release/commit-analyzer": "^11.1.0",
+		"@semantic-release/git": "^10.0.1",
+		"@semantic-release/github": "^9.2.6",
+		"@semantic-release/npm": "^11.0.2",
+		"@semantic-release/release-notes-generator": "^12.1.0",
 		"@size-limit/preset-small-lib": "11.0.2",
 		"@testing-library/cypress": "10.0.1",
 		"@testing-library/jest-dom": "6.4.2",
@@ -100,6 +106,7 @@
 		"react-router": "^6.22.1",
 		"react-router-dom": "^6.22.1",
 		"sass": "1.71.1",
+		"semantic-release": "^22.0.12",
 		"size-limit": "11.0.2",
 		"start-server-and-test": "2.0.3",
 		"typescript": "5.3.3",


### PR DESCRIPTION
Adds support for publishing automatically the library's package to npm using semantic-release and commitizen.

Note:
- This requires having these keys correctly configured in the project
  - GITHUB_TOKEN
  - NPM_TOKEN 

Closes #24 